### PR TITLE
namespace isolation and new integration tests for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,12 @@ jobs:
     - name: Build test dependencies (healthworker)
       run: go build ./testdata/healthworker/...
 
-    - name: Run cgroup integration tests (as root)
+    - name: Run cgroup + namespace integration tests (as root)
       if: env.CGROUP_AVAILABLE == 'true'
       run: |
         sudo --preserve-env=PATH,GOPATH,GOCACHE,HOME \
           env HERD_CGROUP_TEST=1 \
-          $(which go) test -v -run TestSandbox -timeout 60s ./...
+          $(which go) test -v -run 'TestSandbox|TestNamespace' -timeout 90s ./...
       env:
         GOPATH: ${{ env.GOPATH }}
         GOCACHE: ${{ env.GOCACHE }}

--- a/factory_cgroup_test.go
+++ b/factory_cgroup_test.go
@@ -25,6 +25,13 @@ func TestNewProcessFactory_DefaultMemoryCPUUnlimited(t *testing.T) {
 	}
 }
 
+func TestNewProcessFactory_DefaultNamespaceFlags(t *testing.T) {
+	f := NewProcessFactory("./fake-binary")
+	if f.namespaceCloneFlags != defaultNamespaceCloneFlags() {
+		t.Errorf("expected default namespaceCloneFlags=%d, got %d", defaultNamespaceCloneFlags(), f.namespaceCloneFlags)
+	}
+}
+
 func TestWithMemoryLimit_StoresBytes(t *testing.T) {
 	const limit = 512 * 1024 * 1024 // 512 MB
 	f := NewProcessFactory("./fake-binary").WithMemoryLimit(limit)

--- a/process_worker_factory.go
+++ b/process_worker_factory.go
@@ -172,6 +172,7 @@ type ProcessFactory struct {
 	startTimeout          time.Duration // maximum time to wait for the first successful health check
 	startHealthCheckDelay time.Duration // delay the health check for the first time.
 	enableSandbox         bool          // true by default for isolation
+	namespaceCloneFlags   uintptr       // Linux namespaces to enable for sandboxed workers
 	cgroupMemory          int64         // bytes; 0 means unlimited
 	cgroupCPU             int64         // quota in micros per 100ms period; 0 means unlimited
 	cgroupPIDs            int64         // max pids; -1 means unlimited
@@ -193,6 +194,7 @@ func NewProcessFactory(binary string, args ...string) *ProcessFactory {
 		startTimeout:          30 * time.Second,
 		startHealthCheckDelay: 1 * time.Second,
 		enableSandbox:         true,
+		namespaceCloneFlags:   defaultNamespaceCloneFlags(),
 		cgroupPIDs:            100,
 	}
 }
@@ -331,6 +333,7 @@ func (f *ProcessFactory) Spawn(ctx context.Context) (Worker[*http.Client], error
 			memoryMaxBytes: f.cgroupMemory,
 			cpuMaxMicros:   f.cgroupCPU,
 			pidsMax:        f.cgroupPIDs,
+			cloneFlags:     f.namespaceCloneFlags,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("herd: ProcessFactory: failed to apply sandbox: %w", err)

--- a/sandbox.go
+++ b/sandbox.go
@@ -6,6 +6,7 @@ type sandboxConfig struct {
 	memoryMaxBytes int64
 	cpuMaxMicros   int64
 	pidsMax        int64
+	cloneFlags     uintptr
 }
 
 // sandboxHandle owns post-start and cleanup hooks for sandbox resources.

--- a/sandbox_integration_test.go
+++ b/sandbox_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -239,4 +240,66 @@ func TestSandbox_MemoryLimitFileWritten(t *testing.T) {
 	}
 	t.Logf("memory limits confirmed: max=%s swap=%s",
 		strings.TrimSpace(string(memMax)), strings.TrimSpace(string(swapMax)))
+}
+
+func TestNamespace_PIDIsolation(t *testing.T) {
+	requireCgroupIntegration(t)
+
+	bin := buildHealthWorker(t)
+
+	factory := NewProcessFactory(bin).
+		WithHealthPath("/health").
+		WithStartTimeout(10 * time.Second).
+		WithStartHealthCheckDelay(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	worker, err := factory.Spawn(ctx)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	defer worker.Close()
+
+	pw, ok := worker.(*processWorker)
+	if !ok {
+		t.Fatal("expected *processWorker from Spawn")
+	}
+	pw.mu.Lock()
+	hostPID := pw.cmd.Process.Pid
+	pw.mu.Unlock()
+
+	statusFile := fmt.Sprintf("/proc/%d/status", hostPID)
+	status, err := os.ReadFile(statusFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", statusFile, err)
+	}
+
+	insidePID, ok := parseInnermostNSpid(string(status))
+	if !ok {
+		t.Fatalf("NSpid line not found in %s:\n%s", statusFile, string(status))
+	}
+	if insidePID != 1 {
+		t.Fatalf("expected worker to be PID 1 inside its namespace, got %d", insidePID)
+	}
+	t.Logf("NSpid verified: host pid=%d, namespace pid=%d", hostPID, insidePID)
+}
+
+func parseInnermostNSpid(status string) (int, bool) {
+	for _, line := range strings.Split(status, "\n") {
+		if !strings.HasPrefix(line, "NSpid:") {
+			continue
+		}
+		fields := strings.Fields(strings.TrimPrefix(line, "NSpid:"))
+		if len(fields) == 0 {
+			return 0, false
+		}
+		last := fields[len(fields)-1]
+		pid, err := strconv.Atoi(last)
+		if err != nil {
+			return 0, false
+		}
+		return pid, true
+	}
+	return 0, false
 }

--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -113,7 +113,7 @@ func applySandboxFlags(cmd *exec.Cmd, workerID string, cfg sandboxConfig) (sandb
 		sys = &syscall.SysProcAttr{}
 	}
 	if cfg.cloneFlags != 0 {
-		sys.CloneFlags |= cfg.cloneFlags
+		sys.Cloneflags |= cfg.cloneFlags
 	}
 	sys.CgroupFD = int(dir.Fd())
 	sys.UseCgroupFD = true

--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -112,11 +112,18 @@ func applySandboxFlags(cmd *exec.Cmd, workerID string, cfg sandboxConfig) (sandb
 	if sys == nil {
 		sys = &syscall.SysProcAttr{}
 	}
+	if cfg.cloneFlags != 0 {
+		sys.CloneFlags |= cfg.cloneFlags
+	}
 	sys.CgroupFD = int(dir.Fd())
 	sys.UseCgroupFD = true
 	cmd.SysProcAttr = sys
 
 	return &cgroupHandle{path: cgroupPath, fd: dir}, nil
+}
+
+func defaultNamespaceCloneFlags() uintptr {
+	return uintptr(syscall.CLONE_NEWPID | syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC)
 }
 
 func writeCgroupFile(cgroupPath, filename, value string) error {

--- a/sandbox_linux_test.go
+++ b/sandbox_linux_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -160,6 +161,32 @@ func TestApplySandboxFlags_SysProcAttrWired(t *testing.T) {
 	}
 	if cmd.SysProcAttr.CgroupFD <= 0 {
 		t.Errorf("CgroupFD should be a valid fd (>0), got %d", cmd.SysProcAttr.CgroupFD)
+	}
+}
+
+func TestApplySandboxFlags_CloneFlagsMergedWithCgroup(t *testing.T) {
+	withTempCgroupRoot(t)
+	cmd := newFakeCmd()
+
+	flags := uintptr(syscall.CLONE_NEWPID | syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC)
+	h, err := applySandboxFlags(cmd, "worker-ns", sandboxConfig{cloneFlags: flags})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h == nil {
+		t.Fatal("expected non-nil handle")
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr should be set after applySandboxFlags")
+	}
+	if cmd.SysProcAttr.CloneFlags&flags != flags {
+		t.Errorf("expected CloneFlags to include %#x, got %#x", flags, cmd.SysProcAttr.CloneFlags)
+	}
+	if !cmd.SysProcAttr.UseCgroupFD {
+		t.Error("UseCgroupFD should remain true after namespace merge")
+	}
+	if cmd.SysProcAttr.CgroupFD <= 0 {
+		t.Errorf("CgroupFD should remain set after namespace merge, got %d", cmd.SysProcAttr.CgroupFD)
 	}
 }
 

--- a/sandbox_linux_test.go
+++ b/sandbox_linux_test.go
@@ -179,8 +179,8 @@ func TestApplySandboxFlags_CloneFlagsMergedWithCgroup(t *testing.T) {
 	if cmd.SysProcAttr == nil {
 		t.Fatal("SysProcAttr should be set after applySandboxFlags")
 	}
-	if cmd.SysProcAttr.CloneFlags&flags != flags {
-		t.Errorf("expected CloneFlags to include %#x, got %#x", flags, cmd.SysProcAttr.CloneFlags)
+	if cmd.SysProcAttr.Cloneflags&flags != flags {
+		t.Errorf("expected Cloneflags to include %#x, got %#x", flags, cmd.SysProcAttr.Cloneflags)
 	}
 	if !cmd.SysProcAttr.UseCgroupFD {
 		t.Error("UseCgroupFD should remain true after namespace merge")

--- a/sandbox_unsupported.go
+++ b/sandbox_unsupported.go
@@ -27,3 +27,7 @@ var ErrSandboxUnsupported = errors.New(
 func applySandboxFlags(cmd *exec.Cmd, workerID string, cfg sandboxConfig) (sandboxHandle, error) {
 	return nil, ErrSandboxUnsupported
 }
+
+func defaultNamespaceCloneFlags() uintptr {
+	return 0
+}


### PR DESCRIPTION
This pull request adds support for Linux PID namespace isolation in the process worker sandbox, ensuring that each worker runs as PID 1 in its own namespace. It introduces a new `namespaceCloneFlags` option to `ProcessFactory`, sets sensible defaults, and adds integration tests to verify namespace isolation. The changes also update the CI workflow to run the new namespace tests.

**Namespace isolation support:**

* Added `namespaceCloneFlags` field to `ProcessFactory`, initialized to `defaultNamespaceCloneFlags()` (PID, mount, and IPC namespaces) by default, and passed through to the sandbox configuration (`process_worker_factory.go`, `sandbox.go`). [[1]](diffhunk://#diff-d86d7bc9f8960d3714f3534ca33f97885dd43de1236f7832c643a43cd43967d9R175) [[2]](diffhunk://#diff-d86d7bc9f8960d3714f3534ca33f97885dd43de1236f7832c643a43cd43967d9R197) [[3]](diffhunk://#diff-d86d7bc9f8960d3714f3534ca33f97885dd43de1236f7832c643a43cd43967d9R336) [[4]](diffhunk://#diff-ddb74f563edcc0f8d19dd0509ffcc1aa2b1a96aaa27e9ec821f8d87a70a3b577R9)
* Implemented `defaultNamespaceCloneFlags()` for Linux and stubbed it for unsupported platforms, ensuring platform compatibility (`sandbox_linux.go`, `sandbox_unsupported.go`). [[1]](diffhunk://#diff-122e7b6248d106299c03841619ccec3b3269d2854eff7fe44cff3458499c775dR115-R128) [[2]](diffhunk://#diff-d024389d391b4c8549e91429cbf9286339282049af1e997a6fcd8c32f300239bR30-R33)
* Modified `applySandboxFlags` to merge namespace clone flags with cgroup flags and set them in `SysProcAttr` (`sandbox_linux.go`).

**Testing improvements:**

* Added `TestNamespace_PIDIsolation` integration test to verify that the worker process is PID 1 inside its namespace, and helper to parse the `NSpid` field from `/proc/[pid]/status` (`sandbox_integration_test.go`).
* Added `TestApplySandboxFlags_CloneFlagsMergedWithCgroup` unit test to ensure correct merging of namespace and cgroup flags (`sandbox_linux_test.go`).
* Added `TestNewProcessFactory_DefaultNamespaceFlags` to verify default namespace flags in new factories (`factory_cgroup_test.go`).

**CI workflow update:**

* Updated the CI workflow to run both cgroup and namespace integration tests, increasing the timeout accordingly (`.github/workflows/ci.yml`).