### PR TITLE
mkdocs deployment to github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - ci/building_and_hosting_on_gh_pages  # Allow testing inside your active branch
+      
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - ci/building_and_hosting_on_gh_pages  # Allow testing inside your active branch
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: write   # Crucial permission for mkdocs gh-deploy to push to gh-pages branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-docs.txt ]; then pip install -r requirements-docs.txt; else pip install mkdocs mkdocs-material; fi
+
+      - name: Deploy to GitHub Pages
+        run: |
+          mkdocs gh-deploy --force


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of project documentation using MkDocs. The workflow is triggered on pushes to specific branches and relevant documentation files, ensuring that documentation is always up-to-date on GitHub Pages.

**Documentation Deployment Automation:**

* Added a new workflow file `.github/workflows/docs.yml` to automate building and deploying documentation to GitHub Pages using MkDocs. The workflow installs dependencies, builds the documentation, and pushes the result to the `gh-pages` branch on pushes to the `main` or `ci/building_and_hosting_on_gh_pages` branches when documentation-related files change.