### PR TITLE
sigkill on daemon death to cleanup any zombie process

### DIFF
--- a/internal/core/os_attrs_linux.go
+++ b/internal/core/os_attrs_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package core
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// ApplyOSAttributes applies OS-specific attributes to the given command.
+// On Linux, this ensures Pdeathsig is set to SIGKILL to prevent zombie processes.
+func ApplyOSAttributes(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	// Pdeathsig ensures that if the parent process (herd) dies unexpectedly,
+	// the kernel will immediately send SIGKILL to the child process.
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+}

--- a/internal/core/os_attrs_nonlinux.go
+++ b/internal/core/os_attrs_nonlinux.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package core
+
+import "os/exec"
+
+// ApplyOSAttributes applies OS-specific attributes to the given command.
+// On non-Linux systems, this is a no-op as Pdeathsig or equivalent is not universally available.
+func ApplyOSAttributes(cmd *exec.Cmd) {
+	// No-op for macOS/Windows. Graceful shutdown must rely on explicit tracking.
+}

--- a/process_worker_factory.go
+++ b/process_worker_factory.go
@@ -334,6 +334,10 @@ func (f *ProcessFactory) Spawn(ctx context.Context) (Worker[*http.Client], error
 	// During program exits, this should be cleaned up by the Shutdown method
 	cmd := exec.Command(f.binary, resolvedArgs...)
 	cmd.Env = append(os.Environ(), append([]string{"PORT=" + portStr}, resolvedEnv...)...)
+
+	// Apply OS-specific attributes (e.g. Pdeathsig on Linux) to prevent zombies
+	core.ApplyOSAttributes(cmd)
+
 	var cgroupHandle core.SandboxHandle
 
 	if f.enableSandbox {


### PR DESCRIPTION
This pull request introduces an OS-specific abstraction for applying process attributes when spawning child processes, with a focus on preventing zombie processes on Linux. The main change is the addition of the `ApplyOSAttributes` function, which sets the `Pdeathsig` attribute on Linux to ensure child processes are killed if the parent dies, and is a no-op on other platforms. This logic is now used in the process worker factory when spawning new processes.

**Platform-specific process handling:**

* Added `ApplyOSAttributes` function in `internal/core/os_attrs_linux.go` that sets `Pdeathsig` to `SIGKILL` on Linux to prevent zombie processes if the parent dies.
* Added a no-op `ApplyOSAttributes` function in `internal/core/os_attrs_nonlinux.go` for non-Linux platforms, ensuring cross-platform compatibility.
* Updated `process_worker_factory.go` to call `core.ApplyOSAttributes(cmd)` when spawning a new process, ensuring the correct OS-specific behavior is applied.