### PR TITLE
adding daemon scaffolding using cobra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - name: Run daemon integration tests
+      run: go test -v -run '^TestDaemonIntegration_' ./internal/daemon
+
     - name: Run tests with race detector
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ examples/ollama/ollama
 .DS_Store
 
 venv
+
+herd

--- a/README.md
+++ b/README.md
@@ -54,6 +54,51 @@ This invariant transforms stateful binaries (like Browsers, LLMs, or REPLs) into
 go get github.com/herd-core/herd
 ```
 
+## 🧱 Daemon Mode (Single-Node)
+
+Herd now supports a standalone daemon runtime for process isolation outside host app memory/crash domains.
+
+Build the daemon:
+
+```bash
+go build -o herd ./cmd/herd
+```
+
+Run with strict config:
+
+```bash
+./herd start --config /etc/herd/config.yaml
+```
+
+Daemon transport split:
+
+- Control plane: gRPC over Unix Domain Socket (`network.control_socket`).
+- Data plane: HTTP proxy over local TCP (`network.data_bind`).
+
+Platform behavior:
+
+- Linux: full guarantee mode.
+- macOS: reduced-guarantee mode with explicit warnings.
+
+For daemon docs see:
+
+- `docs/daemon/install.md`
+- `docs/daemon/cli.md`
+- `docs/daemon/uds.md`
+
+## 🔁 Migration: Embedded Library to Daemon
+
+If you previously embedded Herd in your app (`herd.New(...)` + in-process proxy), migrate to:
+
+1. Run Herd daemon as a separate process.
+2. Acquire/hold session via control stream over UDS.
+3. Send workload HTTP traffic to the daemon data plane with session header (`X-Session-ID`).
+
+Important semantic shift:
+
+- In daemon mode, control stream liveness owns session lifetime.
+- When the control stream closes/errors, the daemon force-kills that session's worker.
+
 ---
 
 ## 🌐 Quick Start: Playwright Browser Isolation

--- a/cmd/herd/main.go
+++ b/cmd/herd/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "fmt"
+import (
+	"log"
+	"os"
+)
 
 func main() {
-	fmt.Println("Herd Daemon Skeleton")
+	if err := Execute(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/herd/root.go
+++ b/cmd/herd/root.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "herd",
+	Short: "herd is a blazing fast sidecar daemon for process pooling",
+	Long:  `herd transforms passive Go libraries into a production-grade cross-language daemon built for high-performance process pooling.`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() error {
+	return rootCmd.Execute()
+}

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -54,7 +54,10 @@ func runDaemon() {
 		log.Println("Shutting down pool...")
 		// Will assume Shutdown(context.Background()) exists, we'll verify this during compilation check.
 		// If Pool does not have Shutdown, we'll update this. 
-		pool.Shutdown(context.Background())
+		err := pool.Shutdown(context.Background())
+		if err != nil {
+			log.Println("Error shutting down pool:", err)
+		}
 		log.Println("Daemon gracefully stopped.")
 	}()
 

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -2,17 +2,22 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/herd-core/herd"
 	"github.com/herd-core/herd/internal/config"
 	"github.com/herd-core/herd/internal/daemon"
+	pb "github.com/herd-core/herd/proto/herd/v1"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -53,16 +58,47 @@ func runDaemon() {
 	if err != nil {
 		log.Fatalf("failed to initialize pool: %v", err)
 	}
-
 	defer func() {
-		log.Println("Shutting down pool...")
-		// Will assume Shutdown(context.Background()) exists, we'll verify this during compilation check.
-		// If Pool does not have Shutdown, we'll update this.
-		err := pool.Shutdown(context.Background())
-		if err != nil {
-			log.Println("Error shutting down pool:", err)
+		if err := pool.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down pool: %v", err)
 		}
-		log.Println("Daemon gracefully stopped.")
+	}()
+
+	controlLis, err := daemon.ListenUnixSocket(cfg.Network.ControlSocket)
+	if err != nil {
+		log.Fatalf("failed to create control socket listener: %v", err)
+	}
+	defer func() {
+		if err := controlLis.Close(); err != nil {
+			log.Printf("Error closing control listener: %v", err)
+		}
+		if err := daemon.RemoveUnixSocket(cfg.Network.ControlSocket); err != nil {
+			log.Printf("Error cleaning up control socket: %v", err)
+		}
+	}()
+
+	grpcServer := grpc.NewServer()
+	pb.RegisterHerdServiceServer(grpcServer, daemon.NewServer(pool, "http://"+cfg.Network.DataBind, cfg.Resources.MaxWorkers))
+
+	httpServer := &http.Server{
+		Addr:    cfg.Network.DataBind,
+		Handler: daemon.NewDataPlaneHandler(pool, cfg.Telemetry.MetricsPath),
+	}
+
+	errCh := make(chan error, 2)
+
+	go func() {
+		log.Printf("gRPC control plane listening on unix://%s", cfg.Network.ControlSocket)
+		if err := grpcServer.Serve(controlLis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			errCh <- err
+		}
+	}()
+
+	go func() {
+		log.Printf("HTTP data plane listening on http://%s", cfg.Network.DataBind)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
 	}()
 
 	log.Printf("HTTP proxy will listen on %s", cfg.Network.DataBind)
@@ -70,9 +106,34 @@ func runDaemon() {
 
 	log.Println("Daemon is running. Press CTRL+C to stop.")
 
-	// Block until signal is received
-	<-ctx.Done()
-	log.Println("Received shutdown signal. Gracefully stopping...")
+	select {
+	case <-ctx.Done():
+		log.Println("Received shutdown signal. Gracefully stopping...")
+	case err := <-errCh:
+		log.Printf("Daemon listener failed: %v", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		log.Printf("HTTP shutdown error: %v", err)
+	}
+
+	var once sync.Once
+	done := make(chan struct{})
+	go func() {
+		once.Do(grpcServer.GracefulStop)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-shutdownCtx.Done():
+		grpcServer.Stop()
+	}
+
+	log.Println("Daemon gracefully stopped.")
 }
 
 func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/hackstrix/herd"
+	"github.com/herd-core/herd"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/hackstrix/herd"
+	"github.com/spf13/cobra"
+)
+
+var (
+	httpPort   int
+	socketPath string
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the herd daemon",
+	Long:  `Starts the herd daemon, exposing a gRPC Control Plane on a Unix socket and an HTTP Data Plane proxy.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runDaemon()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+	startCmd.Flags().IntVarP(&httpPort, "http-port", "p", 8080, "Port for the HTTP Data Plane proxy")
+	startCmd.Flags().StringVarP(&socketPath, "socket-path", "s", "/tmp/herd.sock", "Path to the Unix socket for the gRPC Control Plane")
+}
+
+func runDaemon() {
+	// 1. Setup graceful shutdown context
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	log.Println("Starting herd daemon...")
+
+	// 2. Initialize the Pool
+	// Note: We use a placeholder factory setup for now. This will be replaced by actual configuration in future phases.
+	factory := herd.NewProcessFactory("echo", "placeholder") 
+	
+	// Ensure we don't error out on unsupported configurations
+	factory.WithStartTimeout(0) 
+
+	pool, err := herd.New(factory)
+	if err != nil {
+		log.Fatalf("failed to initialize pool: %v", err)
+	}
+
+	defer func() {
+		log.Println("Shutting down pool...")
+		// Will assume Shutdown(context.Background()) exists, we'll verify this during compilation check.
+		// If Pool does not have Shutdown, we'll update this. 
+		pool.Shutdown(context.Background())
+		log.Println("Daemon gracefully stopped.")
+	}()
+
+	log.Printf("HTTP proxy will listen on :%d", httpPort)
+	log.Printf("gRPC socket path will be: %s", socketPath)
+
+	log.Println("Daemon is running. Press CTRL+C to stop.")
+
+	// Block until signal is received
+	<-ctx.Done()
+	log.Println("Received shutdown signal. Gracefully stopping...")
+}

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -3,17 +3,20 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/internal/config"
+	"github.com/herd-core/herd/internal/daemon"
 	"github.com/spf13/cobra"
 )
 
 var (
-	httpPort   int
-	socketPath string
+	configPath string
 )
 
 var startCmd = &cobra.Command{
@@ -27,8 +30,7 @@ var startCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(startCmd)
-	startCmd.Flags().IntVarP(&httpPort, "http-port", "p", 8080, "Port for the HTTP Data Plane proxy")
-	startCmd.Flags().StringVarP(&socketPath, "socket-path", "s", "/tmp/herd.sock", "Path to the Unix socket for the gRPC Control Plane")
+	startCmd.Flags().StringVar(&configPath, "config", "/etc/herd/config.yaml", "Path to daemon configuration file")
 }
 
 func runDaemon() {
@@ -38,14 +40,16 @@ func runDaemon() {
 
 	log.Println("Starting herd daemon...")
 
-	// 2. Initialize the Pool
-	// Note: We use a placeholder factory setup for now. This will be replaced by actual configuration in future phases.
-	factory := herd.NewProcessFactory("echo", "placeholder") 
-	
-	// Ensure we don't error out on unsupported configurations
-	factory.WithStartTimeout(0) 
+	if err := daemon.EnforceRuntimePolicy(runtime.GOOS, log.Default()); err != nil {
+		log.Fatal(err)
+	}
 
-	pool, err := herd.New(factory)
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		log.Fatalf("failed to load config %q: %v", configPath, err)
+	}
+
+	pool, err := buildPool(cfg)
 	if err != nil {
 		log.Fatalf("failed to initialize pool: %v", err)
 	}
@@ -53,7 +57,7 @@ func runDaemon() {
 	defer func() {
 		log.Println("Shutting down pool...")
 		// Will assume Shutdown(context.Background()) exists, we'll verify this during compilation check.
-		// If Pool does not have Shutdown, we'll update this. 
+		// If Pool does not have Shutdown, we'll update this.
 		err := pool.Shutdown(context.Background())
 		if err != nil {
 			log.Println("Error shutting down pool:", err)
@@ -61,12 +65,43 @@ func runDaemon() {
 		log.Println("Daemon gracefully stopped.")
 	}()
 
-	log.Printf("HTTP proxy will listen on :%d", httpPort)
-	log.Printf("gRPC socket path will be: %s", socketPath)
+	log.Printf("HTTP proxy will listen on %s", cfg.Network.DataBind)
+	log.Printf("gRPC socket path will be: %s", cfg.Network.ControlSocket)
 
 	log.Println("Daemon is running. Press CTRL+C to stop.")
 
 	// Block until signal is received
 	<-ctx.Done()
 	log.Println("Received shutdown signal. Gracefully stopping...")
+}
+
+func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {
+	factory := herd.NewProcessFactory(cfg.Worker.Command[0], cfg.Worker.Command[1:]...).
+		WithHealthPath(cfg.Worker.HealthPath).
+		WithStartTimeout(cfg.Worker.StartTimeoutDuration()).
+		WithStartHealthCheckDelay(cfg.Worker.StartHealthCheckDelayDuration())
+
+	for _, envKV := range cfg.Worker.Env {
+		factory.WithEnv(envKV)
+	}
+
+	if cfg.Resources.MemoryLimitBytes() > 0 {
+		factory.WithMemoryLimit(cfg.Resources.MemoryLimitBytes())
+	}
+	if cfg.Resources.CPULimitCores > 0 {
+		factory.WithCPULimit(cfg.Resources.CPULimitCores)
+	}
+	if cfg.Resources.PIDsLimit != 0 {
+		factory.WithPIDsLimit(cfg.Resources.PIDsLimit)
+	}
+	if cfg.Resources.InsecureSandbox {
+		factory.WithInsecureSandbox()
+	}
+
+	return herd.New(factory,
+		herd.WithAutoScale(cfg.Resources.MinWorkers, cfg.Resources.MaxWorkers),
+		herd.WithTTL(cfg.Resources.TTLDuration()),
+		herd.WithHealthInterval(cfg.Resources.HealthIntervalDuration()),
+		herd.WithWorkerReuse(cfg.Resources.WorkerReuse),
+	)
 }

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -53,6 +53,14 @@ func runDaemon() {
 	if err != nil {
 		log.Fatalf("failed to load config %q: %v", configPath, err)
 	}
+	eventLogger := daemon.NewEventLogger(cfg.Telemetry.LogFormat, log.Default())
+	eventLogger.Info("daemon_starting", map[string]any{
+		"config_path":      configPath,
+		"control_socket":   cfg.Network.ControlSocket,
+		"data_bind":        cfg.Network.DataBind,
+		"metrics_path":     cfg.Telemetry.MetricsPath,
+		"telemetry_format": cfg.Telemetry.LogFormat,
+	})
 
 	pool, err := buildPool(cfg)
 	if err != nil {
@@ -60,7 +68,7 @@ func runDaemon() {
 	}
 	defer func() {
 		if err := pool.Shutdown(context.Background()); err != nil {
-			log.Printf("Error shutting down pool: %v", err)
+			eventLogger.Error("pool_shutdown_failed", map[string]any{"error": err})
 		}
 	}()
 
@@ -70,15 +78,15 @@ func runDaemon() {
 	}
 	defer func() {
 		if err := controlLis.Close(); err != nil {
-			log.Printf("Error closing control listener: %v", err)
+			eventLogger.Error("control_listener_close_failed", map[string]any{"error": err})
 		}
 		if err := daemon.RemoveUnixSocket(cfg.Network.ControlSocket); err != nil {
-			log.Printf("Error cleaning up control socket: %v", err)
+			eventLogger.Error("control_socket_cleanup_failed", map[string]any{"error": err})
 		}
 	}()
 
 	grpcServer := grpc.NewServer()
-	pb.RegisterHerdServiceServer(grpcServer, daemon.NewServer(pool, "http://"+cfg.Network.DataBind, cfg.Resources.MaxWorkers))
+	pb.RegisterHerdServiceServer(grpcServer, daemon.NewServer(pool, "http://"+cfg.Network.DataBind, cfg.Resources.MaxWorkers, eventLogger))
 
 	httpServer := &http.Server{
 		Addr:    cfg.Network.DataBind,
@@ -88,36 +96,33 @@ func runDaemon() {
 	errCh := make(chan error, 2)
 
 	go func() {
-		log.Printf("gRPC control plane listening on unix://%s", cfg.Network.ControlSocket)
+		eventLogger.Info("control_plane_listening", map[string]any{"address": "unix://" + cfg.Network.ControlSocket})
 		if err := grpcServer.Serve(controlLis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			errCh <- err
 		}
 	}()
 
 	go func() {
-		log.Printf("HTTP data plane listening on http://%s", cfg.Network.DataBind)
+		eventLogger.Info("data_plane_listening", map[string]any{"address": "http://" + cfg.Network.DataBind})
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
 	}()
 
-	log.Printf("HTTP proxy will listen on %s", cfg.Network.DataBind)
-	log.Printf("gRPC socket path will be: %s", cfg.Network.ControlSocket)
-
-	log.Println("Daemon is running. Press CTRL+C to stop.")
+	eventLogger.Info("daemon_running", map[string]any{})
 
 	select {
 	case <-ctx.Done():
-		log.Println("Received shutdown signal. Gracefully stopping...")
+		eventLogger.Info("daemon_shutdown_signal_received", map[string]any{})
 	case err := <-errCh:
-		log.Printf("Daemon listener failed: %v", err)
+		eventLogger.Error("daemon_listener_failed", map[string]any{"error": err})
 	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		log.Printf("HTTP shutdown error: %v", err)
+		eventLogger.Error("data_plane_shutdown_failed", map[string]any{"error": err})
 	}
 
 	var once sync.Once
@@ -130,10 +135,11 @@ func runDaemon() {
 	select {
 	case <-done:
 	case <-shutdownCtx.Done():
+		eventLogger.Warn("control_plane_graceful_shutdown_timeout", map[string]any{})
 		grpcServer.Stop()
 	}
 
-	log.Println("Daemon gracefully stopped.")
+	eventLogger.Info("daemon_stopped", map[string]any{})
 }
 
 func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {

--- a/docs/daemon/cli.md
+++ b/docs/daemon/cli.md
@@ -1,1 +1,39 @@
 # CLI Reference
+
+## Command
+
+```bash
+herd start --config /etc/herd/config.yaml
+```
+
+## Flags
+
+- `--config`: path to daemon YAML config (default: `/etc/herd/config.yaml`).
+
+The daemon is strict config-first. Unknown YAML keys and invalid values fail startup.
+
+## Startup Contract
+
+On successful start, `herd start`:
+
+1. Validates runtime policy (Linux full guarantees, macOS reduced guarantees).
+2. Loads and validates config.
+3. Bootstraps worker pool from config.
+4. Starts control plane gRPC on Unix socket.
+5. Starts data plane HTTP server on local TCP bind.
+
+Any failure in these steps terminates startup immediately.
+
+## Control/Data Split
+
+- Control plane: gRPC on `network.control_socket` (Unix Domain Socket).
+- Data plane: HTTP on `network.data_bind`.
+
+## Session Lifecycle in Daemon Mode
+
+- Clients establish a control stream via `Acquire` over UDS.
+- Daemon allocates one pinned session per stream.
+- On stream close/error, daemon force-kills that session's worker.
+
+This behavior is intentional for stateful workload cleanup and crash containment.
+

--- a/docs/daemon/install.md
+++ b/docs/daemon/install.md
@@ -1,1 +1,55 @@
 # Installation (Daemon)
+
+The daemon mode runs as a standalone binary and is configured via a strict YAML file.
+
+## Build
+
+```bash
+go build -o herd ./cmd/herd
+```
+
+## Minimal Config
+
+Create a config file at `/etc/herd/config.yaml` (or any path and pass it with `--config`).
+
+```yaml
+network:
+	control_socket: /tmp/herd.sock
+	data_bind: 127.0.0.1:4000
+
+worker:
+	command: ["python3", "worker.py"]
+	env:
+		- PYTHONUNBUFFERED=1
+	health_path: /health
+	start_timeout: 30s
+	start_health_check_delay: 1s
+
+resources:
+	min_workers: 1
+	max_workers: 4
+	memory_limit_mb: 512
+	cpu_limit_cores: 1
+	pids_limit: 100
+	ttl: 10m
+	health_interval: 5s
+	worker_reuse: true
+	insecure_sandbox: false
+
+telemetry:
+	log_format: json
+	metrics_path: /metrics
+```
+
+## Run
+
+```bash
+./herd start --config /etc/herd/config.yaml
+```
+
+## Platform Guarantees
+
+- Linux: full guarantee mode, including parent-death kill behavior for child workers.
+- macOS: reduced-guarantee mode with explicit warnings; orphan prevention is best-effort.
+- Other platforms: startup fails fast.
+

--- a/docs/daemon/uds.md
+++ b/docs/daemon/uds.md
@@ -1,1 +1,47 @@
 # Unix Domain Sockets
+
+Herd uses Unix Domain Sockets (UDS) for the local control plane in single-node daemon mode.
+
+## Why UDS
+
+- Keeps control traffic local to the host.
+- Avoids exposing control APIs over TCP.
+- Simplifies local SDK connectivity and access controls.
+
+## Socket Path
+
+Configured via:
+
+```yaml
+network:
+	control_socket: /tmp/herd.sock
+```
+
+Validation rules:
+
+- Must be an absolute path.
+- Must fit Unix socket path length limits.
+
+## Security and Lifecycle
+
+At daemon startup:
+
+1. Any stale socket file is removed.
+2. Socket is re-created and bound.
+3. Permissions are set to `0600`.
+
+At daemon shutdown:
+
+1. gRPC server stops.
+2. Listener closes.
+3. Socket file is removed.
+
+## Control Stream Semantics
+
+The control stream owns session liveness.
+
+- If stream closes normally (`io.EOF`), session worker is force-terminated.
+- If stream breaks with error, session worker is force-terminated.
+
+This prevents leaked stateful subprocesses after local client crashes.
+

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/herd-core/herd
 go 1.24.0
 
 require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
@@ -12,3 +21,4 @@ google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aO
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -22,3 +22,5 @@ google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,11 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -12,9 +16,10 @@ import (
 // Config is the strict daemon bootstrap contract.
 // The daemon fails fast if any required field is missing or malformed.
 type Config struct {
-	Network   NetworkConfig  `yaml:"network"`
-	Worker    WorkerConfig   `yaml:"worker"`
-	Resources ResourceConfig `yaml:"resources"`
+	Network   NetworkConfig   `yaml:"network"`
+	Worker    WorkerConfig    `yaml:"worker"`
+	Resources ResourceConfig  `yaml:"resources"`
+	Telemetry TelemetryConfig `yaml:"telemetry"`
 }
 
 type NetworkConfig struct {
@@ -53,6 +58,11 @@ type ResourceConfig struct {
 	// InsecureSandbox enables reduced sandboxing for local development.
 	// This should not be enabled in production.
 	InsecureSandbox bool `yaml:"insecure_sandbox"`
+}
+
+type TelemetryConfig struct {
+	LogFormat   string `yaml:"log_format"`
+	MetricsPath string `yaml:"metrics_path"`
 }
 
 func (r ResourceConfig) TTLDuration() time.Duration {
@@ -106,17 +116,49 @@ func (c *Config) applyDefaults() {
 	if c.Resources.TTL == "" {
 		c.Resources.TTL = "5m"
 	}
+	if c.Telemetry.LogFormat == "" {
+		c.Telemetry.LogFormat = "json"
+	}
+	if c.Telemetry.MetricsPath == "" {
+		c.Telemetry.MetricsPath = "/metrics"
+	}
 }
 
 func (c *Config) Validate() error {
 	if c.Network.ControlSocket == "" {
 		return fmt.Errorf("network.control_socket is required")
 	}
+	if !filepath.IsAbs(c.Network.ControlSocket) {
+		return fmt.Errorf("network.control_socket must be an absolute path")
+	}
+	if len(c.Network.ControlSocket) > 103 {
+		return fmt.Errorf("network.control_socket path is too long (>103 bytes for unix domain sockets)")
+	}
 	if c.Network.DataBind == "" {
 		return fmt.Errorf("network.data_bind is required")
 	}
+	if err := validateDataBind(c.Network.DataBind); err != nil {
+		return fmt.Errorf("network.data_bind invalid: %w", err)
+	}
 	if len(c.Worker.Command) == 0 || c.Worker.Command[0] == "" {
 		return fmt.Errorf("worker.command must include at least one entry (binary)")
+	}
+	for i, arg := range c.Worker.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("worker.command[%d] must not be empty", i)
+		}
+	}
+	if !strings.HasPrefix(c.Worker.HealthPath, "/") {
+		return fmt.Errorf("worker.health_path must start with '/'")
+	}
+	for i, envKV := range c.Worker.Env {
+		if strings.TrimSpace(envKV) == "" {
+			return fmt.Errorf("worker.env[%d] must not be empty", i)
+		}
+		eq := strings.Index(envKV, "=")
+		if eq <= 0 {
+			return fmt.Errorf("worker.env[%d] must be in KEY=VALUE format", i)
+		}
 	}
 	if c.Resources.MinWorkers < 1 {
 		return fmt.Errorf("resources.min_workers must be >= 1")
@@ -133,17 +175,53 @@ func (c *Config) Validate() error {
 	if c.Resources.PIDsLimit == 0 || c.Resources.PIDsLimit < -1 {
 		return fmt.Errorf("resources.pids_limit must be > 0 or -1")
 	}
-	if _, err := time.ParseDuration(c.Worker.StartTimeout); err != nil {
+	if d, err := time.ParseDuration(c.Worker.StartTimeout); err != nil {
 		return fmt.Errorf("worker.start_timeout invalid duration: %w", err)
+	} else if d <= 0 {
+		return fmt.Errorf("worker.start_timeout must be > 0")
 	}
-	if _, err := time.ParseDuration(c.Worker.StartHealthCheckDelay); err != nil {
+	if d, err := time.ParseDuration(c.Worker.StartHealthCheckDelay); err != nil {
 		return fmt.Errorf("worker.start_health_check_delay invalid duration: %w", err)
+	} else if d < 0 {
+		return fmt.Errorf("worker.start_health_check_delay must be >= 0")
 	}
-	if _, err := time.ParseDuration(c.Resources.TTL); err != nil {
+	if d, err := time.ParseDuration(c.Resources.TTL); err != nil {
 		return fmt.Errorf("resources.ttl invalid duration: %w", err)
+	} else if d <= 0 {
+		return fmt.Errorf("resources.ttl must be > 0")
 	}
-	if _, err := time.ParseDuration(c.Resources.HealthInterval); err != nil {
+	if d, err := time.ParseDuration(c.Resources.HealthInterval); err != nil {
 		return fmt.Errorf("resources.health_interval invalid duration: %w", err)
+	} else if d <= 0 {
+		return fmt.Errorf("resources.health_interval must be > 0")
 	}
+	if c.Telemetry.LogFormat != "json" && c.Telemetry.LogFormat != "text" {
+		return fmt.Errorf("telemetry.log_format must be one of: json, text")
+	}
+	if !strings.HasPrefix(c.Telemetry.MetricsPath, "/") {
+		return fmt.Errorf("telemetry.metrics_path must start with '/'")
+	}
+	return nil
+}
+
+func validateDataBind(bind string) error {
+	host, portStr, err := net.SplitHostPort(bind)
+	if err != nil {
+		return fmt.Errorf("must be host:port: %w", err)
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("host must be loopback (localhost, 127.0.0.1, or ::1)")
+	}
+
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the strict daemon bootstrap contract.
+// The daemon fails fast if any required field is missing or malformed.
+type Config struct {
+	Network   NetworkConfig  `yaml:"network"`
+	Worker    WorkerConfig   `yaml:"worker"`
+	Resources ResourceConfig `yaml:"resources"`
+}
+
+type NetworkConfig struct {
+	ControlSocket string `yaml:"control_socket"`
+	DataBind      string `yaml:"data_bind"`
+}
+
+type WorkerConfig struct {
+	Command               []string `yaml:"command"`
+	Env                   []string `yaml:"env"`
+	HealthPath            string   `yaml:"health_path"`
+	StartTimeout          string   `yaml:"start_timeout"`
+	StartHealthCheckDelay string   `yaml:"start_health_check_delay"`
+}
+
+func (w WorkerConfig) StartTimeoutDuration() time.Duration {
+	d, _ := time.ParseDuration(w.StartTimeout)
+	return d
+}
+
+func (w WorkerConfig) StartHealthCheckDelayDuration() time.Duration {
+	d, _ := time.ParseDuration(w.StartHealthCheckDelay)
+	return d
+}
+
+type ResourceConfig struct {
+	MinWorkers     int     `yaml:"min_workers"`
+	MaxWorkers     int     `yaml:"max_workers"`
+	MemoryLimitMB  int64   `yaml:"memory_limit_mb"`
+	CPULimitCores  float64 `yaml:"cpu_limit_cores"`
+	PIDsLimit      int64   `yaml:"pids_limit"`
+	TTL            string  `yaml:"ttl"`
+	HealthInterval string  `yaml:"health_interval"`
+	WorkerReuse    bool    `yaml:"worker_reuse"`
+
+	// InsecureSandbox enables reduced sandboxing for local development.
+	// This should not be enabled in production.
+	InsecureSandbox bool `yaml:"insecure_sandbox"`
+}
+
+func (r ResourceConfig) TTLDuration() time.Duration {
+	d, _ := time.ParseDuration(r.TTL)
+	return d
+}
+
+func (r ResourceConfig) HealthIntervalDuration() time.Duration {
+	d, _ := time.ParseDuration(r.HealthInterval)
+	return d
+}
+
+func (r ResourceConfig) MemoryLimitBytes() int64 {
+	return r.MemoryLimitMB * 1024 * 1024
+}
+
+func Load(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg Config
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decode yaml: %w", err)
+	}
+
+	cfg.applyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func (c *Config) applyDefaults() {
+	if c.Worker.HealthPath == "" {
+		c.Worker.HealthPath = "/health"
+	}
+	if c.Worker.StartTimeout == "" {
+		c.Worker.StartTimeout = "30s"
+	}
+	if c.Worker.StartHealthCheckDelay == "" {
+		c.Worker.StartHealthCheckDelay = "1s"
+	}
+	if c.Resources.HealthInterval == "" {
+		c.Resources.HealthInterval = "5s"
+	}
+	if c.Resources.TTL == "" {
+		c.Resources.TTL = "5m"
+	}
+}
+
+func (c *Config) Validate() error {
+	if c.Network.ControlSocket == "" {
+		return fmt.Errorf("network.control_socket is required")
+	}
+	if c.Network.DataBind == "" {
+		return fmt.Errorf("network.data_bind is required")
+	}
+	if len(c.Worker.Command) == 0 || c.Worker.Command[0] == "" {
+		return fmt.Errorf("worker.command must include at least one entry (binary)")
+	}
+	if c.Resources.MinWorkers < 1 {
+		return fmt.Errorf("resources.min_workers must be >= 1")
+	}
+	if c.Resources.MaxWorkers < c.Resources.MinWorkers {
+		return fmt.Errorf("resources.max_workers must be >= resources.min_workers")
+	}
+	if c.Resources.MemoryLimitMB < 1 {
+		return fmt.Errorf("resources.memory_limit_mb must be >= 1")
+	}
+	if c.Resources.CPULimitCores < 0 {
+		return fmt.Errorf("resources.cpu_limit_cores must be >= 0")
+	}
+	if c.Resources.PIDsLimit == 0 || c.Resources.PIDsLimit < -1 {
+		return fmt.Errorf("resources.pids_limit must be > 0 or -1")
+	}
+	if _, err := time.ParseDuration(c.Worker.StartTimeout); err != nil {
+		return fmt.Errorf("worker.start_timeout invalid duration: %w", err)
+	}
+	if _, err := time.ParseDuration(c.Worker.StartHealthCheckDelay); err != nil {
+		return fmt.Errorf("worker.start_health_check_delay invalid duration: %w", err)
+	}
+	if _, err := time.ParseDuration(c.Resources.TTL); err != nil {
+		return fmt.Errorf("resources.ttl invalid duration: %w", err)
+	}
+	if _, err := time.ParseDuration(c.Resources.HealthInterval); err != nil {
+		return fmt.Errorf("resources.health_interval invalid duration: %w", err)
+	}
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 )
 
-func TestLoad_ValidConfig(t *testing.T) {
-	t.Parallel()
-
-	path := writeTempConfig(t, `
+const validConfigYAML = `
 network:
   control_socket: /tmp/herd.sock
   data_bind: 127.0.0.1:4000
 worker:
   command: ["python3", "worker.py"]
+  env:
+    - FOO=bar
 resources:
   min_workers: 1
   max_workers: 4
@@ -25,7 +24,15 @@ resources:
   ttl: 10m
   health_interval: 5s
   worker_reuse: true
-`)
+telemetry:
+  log_format: json
+  metrics_path: /metrics
+`
+
+func TestLoad_ValidConfig(t *testing.T) {
+	t.Parallel()
+
+	path := writeTempConfig(t, validConfigYAML)
 
 	cfg, err := Load(path)
 	if err != nil {
@@ -36,6 +43,9 @@ resources:
 	}
 	if got := cfg.Worker.StartTimeoutDuration().String(); got != "30s" {
 		t.Fatalf("expected default start_timeout 30s, got %q", got)
+	}
+	if cfg.Telemetry.LogFormat != "json" {
+		t.Fatalf("expected telemetry.log_format=json, got %q", cfg.Telemetry.LogFormat)
 	}
 }
 
@@ -70,23 +80,7 @@ resources:
 func TestLoad_UnknownFieldFails(t *testing.T) {
 	t.Parallel()
 
-	path := writeTempConfig(t, `
-network:
-  control_socket: /tmp/herd.sock
-  data_bind: 127.0.0.1:4000
-worker:
-  command: ["python3", "worker.py"]
-resources:
-  min_workers: 1
-  max_workers: 4
-  memory_limit_mb: 512
-  cpu_limit_cores: 1
-  pids_limit: 100
-  ttl: 10m
-  health_interval: 5s
-  worker_reuse: true
-extra_key: true
-`)
+	path := writeTempConfig(t, validConfigYAML+"\nextra_key: true\n")
 
 	_, err := Load(path)
 	if err == nil {
@@ -94,6 +88,82 @@ extra_key: true
 	}
 	if !strings.Contains(err.Error(), "field extra_key not found") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	path := writeTempConfig(t, "network: [")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected decode yaml error")
+	}
+	if !strings.Contains(err.Error(), "decode yaml") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoad_ValidationMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		yaml       string
+		expectPart string
+	}{
+		{
+			name:       "relative socket path",
+			yaml:       strings.ReplaceAll(validConfigYAML, "/tmp/herd.sock", "tmp/herd.sock"),
+			expectPart: "network.control_socket must be an absolute path",
+		},
+		{
+			name:       "non-loopback data bind",
+			yaml:       strings.ReplaceAll(validConfigYAML, "127.0.0.1:4000", "0.0.0.0:4000"),
+			expectPart: "host must be loopback",
+		},
+		{
+			name:       "invalid worker env",
+			yaml:       strings.ReplaceAll(validConfigYAML, "FOO=bar", "INVALID_ENV"),
+			expectPart: "KEY=VALUE",
+		},
+		{
+			name:       "invalid health path",
+			yaml:       strings.Replace(validConfigYAML, "command: [\"python3\", \"worker.py\"]", "command: [\"python3\", \"worker.py\"]\n  health_path: health", 1),
+			expectPart: "worker.health_path must start with '/'",
+		},
+		{
+			name:       "invalid ttl duration",
+			yaml:       strings.ReplaceAll(validConfigYAML, "ttl: 10m", "ttl: ten"),
+			expectPart: "resources.ttl invalid duration",
+		},
+		{
+			name:       "non-positive health interval",
+			yaml:       strings.ReplaceAll(validConfigYAML, "health_interval: 5s", "health_interval: 0s"),
+			expectPart: "resources.health_interval must be > 0",
+		},
+		{
+			name:       "invalid log format",
+			yaml:       strings.ReplaceAll(validConfigYAML, "log_format: json", "log_format: xml"),
+			expectPart: "telemetry.log_format must be one of",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeTempConfig(t, tt.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.expectPart)
+			}
+			if !strings.Contains(err.Error(), tt.expectPart) {
+				t.Fatalf("expected error containing %q, got %v", tt.expectPart, err)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad_ValidConfig(t *testing.T) {
+	t.Parallel()
+
+	path := writeTempConfig(t, `
+network:
+  control_socket: /tmp/herd.sock
+  data_bind: 127.0.0.1:4000
+worker:
+  command: ["python3", "worker.py"]
+resources:
+  min_workers: 1
+  max_workers: 4
+  memory_limit_mb: 512
+  cpu_limit_cores: 1
+  pids_limit: 100
+  ttl: 10m
+  health_interval: 5s
+  worker_reuse: true
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Network.ControlSocket != "/tmp/herd.sock" {
+		t.Fatalf("unexpected control socket: %q", cfg.Network.ControlSocket)
+	}
+	if got := cfg.Worker.StartTimeoutDuration().String(); got != "30s" {
+		t.Fatalf("expected default start_timeout 30s, got %q", got)
+	}
+}
+
+func TestLoad_MissingRequiredField(t *testing.T) {
+	t.Parallel()
+
+	path := writeTempConfig(t, `
+network:
+  control_socket: /tmp/herd.sock
+worker:
+  command: ["python3", "worker.py"]
+resources:
+  min_workers: 1
+  max_workers: 4
+  memory_limit_mb: 512
+  cpu_limit_cores: 1
+  pids_limit: 100
+  ttl: 10m
+  health_interval: 5s
+  worker_reuse: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for missing network.data_bind")
+	}
+	if !strings.Contains(err.Error(), "network.data_bind") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoad_UnknownFieldFails(t *testing.T) {
+	t.Parallel()
+
+	path := writeTempConfig(t, `
+network:
+  control_socket: /tmp/herd.sock
+  data_bind: 127.0.0.1:4000
+worker:
+  command: ["python3", "worker.py"]
+resources:
+  min_workers: 1
+  max_workers: 4
+  memory_limit_mb: 512
+  cpu_limit_cores: 1
+  pids_limit: 100
+  ttl: 10m
+  health_interval: 5s
+  worker_reuse: true
+extra_key: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected yaml unknown field error")
+	}
+	if !strings.Contains(err.Error(), "field extra_key not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writeTempConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "herd.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}

--- a/internal/daemon/grpc_server.go
+++ b/internal/daemon/grpc_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -23,10 +22,11 @@ type Server struct {
 	proxyAddress string
 	maxWorkers   int
 	seq          atomic.Uint64
+	logger       *EventLogger
 }
 
-func NewServer(pool *herd.Pool[*http.Client], proxyAddress string, maxWorkers int) *Server {
-	return &Server{pool: pool, proxyAddress: proxyAddress, maxWorkers: maxWorkers}
+func NewServer(pool *herd.Pool[*http.Client], proxyAddress string, maxWorkers int, logger *EventLogger) *Server {
+	return &Server{pool: pool, proxyAddress: proxyAddress, maxWorkers: maxWorkers, logger: logger}
 }
 
 // Acquire handles bidirectional streaming allocation.
@@ -42,20 +42,26 @@ func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
 			return
 		}
 		if err := s.pool.KillSession(session.ID); err != nil {
-			log.Printf("[daemon] Acquire stream cleanup failed for session %s: %v", session.ID, err)
+			s.eventLogger().Error("session_kill_failed", map[string]any{"session_id": session.ID, "error": err})
+			return
 		}
+		RecordSessionKilled()
+		s.eventLogger().Info("session_killed", map[string]any{"session_id": session.ID})
 	}()
 
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {
+			s.eventLogger().Info("acquire_stream_closed", map[string]any{})
 			return nil // Client closed gracefully
 		}
 		if err != nil {
+			s.eventLogger().Warn("acquire_stream_broken", map[string]any{"error": err})
 			return err // Stream broken
 		}
+		RecordAcquireRequest()
 
-		log.Printf("Received Acquire Request for worker_type: %s", req.GetWorkerType())
+		s.eventLogger().Info("acquire_request_received", map[string]any{"worker_type": req.GetWorkerType()})
 		if session == nil {
 			sessionID := fmt.Sprintf("sess-%d", s.seq.Add(1))
 			acquireCtx := stream.Context()
@@ -68,8 +74,12 @@ func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
 				session, err = s.pool.Acquire(acquireCtx, sessionID)
 			}
 			if err != nil {
+				RecordAcquireFailure()
+				s.eventLogger().Error("session_acquire_failed", map[string]any{"session_id": sessionID, "error": err})
 				return status.Errorf(codes.ResourceExhausted, "acquire session failed: %v", err)
 			}
+			RecordSessionStarted()
+			s.eventLogger().Info("session_acquired", map[string]any{"session_id": session.ID})
 		}
 
 		resp := &pb.AcquireResponse{
@@ -79,6 +89,7 @@ func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
 		}
 
 		if err := stream.Send(resp); err != nil {
+			s.eventLogger().Warn("acquire_response_send_failed", map[string]any{"session_id": session.ID, "error": err})
 			return err
 		}
 	}
@@ -100,4 +111,11 @@ func (s *Server) Status(ctx context.Context, _ *emptypb.Empty) (*pb.StatusRespon
 		IdleWorkers:   int32(stats.AvailableWorkers),
 		MaxWorkers:    int32(s.maxWorkers),
 	}, nil
+}
+
+func (s *Server) eventLogger() *EventLogger {
+	if s.logger == nil {
+		s.logger = NewEventLogger("text", nil)
+	}
+	return s.logger
 }

--- a/internal/daemon/grpc_server.go
+++ b/internal/daemon/grpc_server.go
@@ -7,9 +7,12 @@ import (
 	"log"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/herd-core/herd"
 	pb "github.com/herd-core/herd/proto/herd/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -28,6 +31,21 @@ func NewServer(pool *herd.Pool[*http.Client], proxyAddress string, maxWorkers in
 
 // Acquire handles bidirectional streaming allocation.
 func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
+	if s.pool == nil {
+		return status.Error(codes.FailedPrecondition, "daemon server is not configured with a pool")
+	}
+
+	var session *herd.Session[*http.Client]
+
+	defer func() {
+		if session == nil {
+			return
+		}
+		if err := s.pool.KillSession(session.ID); err != nil {
+			log.Printf("[daemon] Acquire stream cleanup failed for session %s: %v", session.ID, err)
+		}
+	}()
+
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {
@@ -38,10 +56,24 @@ func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
 		}
 
 		log.Printf("Received Acquire Request for worker_type: %s", req.GetWorkerType())
+		if session == nil {
+			sessionID := fmt.Sprintf("sess-%d", s.seq.Add(1))
+			acquireCtx := stream.Context()
+			if req.GetTimeoutSeconds() > 0 {
+				var cancel context.CancelFunc
+				acquireCtx, cancel = context.WithTimeout(stream.Context(), time.Duration(req.GetTimeoutSeconds())*time.Second)
+				session, err = s.pool.Acquire(acquireCtx, sessionID)
+				cancel()
+			} else {
+				session, err = s.pool.Acquire(acquireCtx, sessionID)
+			}
+			if err != nil {
+				return status.Errorf(codes.ResourceExhausted, "acquire session failed: %v", err)
+			}
+		}
 
-		sessionID := fmt.Sprintf("sess-%d", s.seq.Add(1))
 		resp := &pb.AcquireResponse{
-			SessionId:    sessionID,
+			SessionId:    session.ID,
 			ProxyAddress: s.proxyAddress,
 			WorkerPid:    0,
 		}

--- a/internal/daemon/grpc_server.go
+++ b/internal/daemon/grpc_server.go
@@ -2,9 +2,13 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"sync/atomic"
 
+	"github.com/herd-core/herd"
 	pb "github.com/herd-core/herd/proto/herd/v1"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -12,11 +16,14 @@ import (
 // Server implements the HerdService gRPC server.
 type Server struct {
 	pb.UnimplementedHerdServiceServer
-	// In Phase 3, we will add a reference to the core Pool structure here.
+	pool         *herd.Pool[*http.Client]
+	proxyAddress string
+	maxWorkers   int
+	seq          atomic.Uint64
 }
 
-func NewServer() *Server {
-	return &Server{}
+func NewServer(pool *herd.Pool[*http.Client], proxyAddress string, maxWorkers int) *Server {
+	return &Server{pool: pool, proxyAddress: proxyAddress, maxWorkers: maxWorkers}
 }
 
 // Acquire handles bidirectional streaming allocation.
@@ -32,11 +39,11 @@ func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
 
 		log.Printf("Received Acquire Request for worker_type: %s", req.GetWorkerType())
 
-		// TODO: In Phase 3, map this to core.Pool.Acquire()
+		sessionID := fmt.Sprintf("sess-%d", s.seq.Add(1))
 		resp := &pb.AcquireResponse{
-			SessionId:    "stub-session-123",
-			ProxyAddress: "http://127.0.0.1:8080",
-			WorkerPid:    9999,
+			SessionId:    sessionID,
+			ProxyAddress: s.proxyAddress,
+			WorkerPid:    0,
 		}
 
 		if err := stream.Send(resp); err != nil {
@@ -47,9 +54,18 @@ func (s *Server) Acquire(stream pb.HerdService_AcquireServer) error {
 
 // Status returns daemon health metrics.
 func (s *Server) Status(ctx context.Context, _ *emptypb.Empty) (*pb.StatusResponse, error) {
+	if s.pool == nil {
+		return &pb.StatusResponse{
+			ActiveWorkers: 0,
+			IdleWorkers:   0,
+			MaxWorkers:    int32(s.maxWorkers),
+		}, nil
+	}
+
+	stats := s.pool.Stats()
 	return &pb.StatusResponse{
-		ActiveWorkers: 0,
-		IdleWorkers:   2,
-		MaxWorkers:    10,
+		ActiveWorkers: int32(stats.ActiveSessions),
+		IdleWorkers:   int32(stats.AvailableWorkers),
+		MaxWorkers:    int32(s.maxWorkers),
 	}, nil
 }

--- a/internal/daemon/grpc_server_test.go
+++ b/internal/daemon/grpc_server_test.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/herd-core/herd"
 	pb "github.com/herd-core/herd/proto/herd/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -16,15 +22,21 @@ const bufSize = 1024 * 1024
 
 var lis *bufconn.Listener
 
-func initGRPCServer() {
+func initGRPCServer(t *testing.T, srv pb.HerdServiceServer) {
+	t.Helper()
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer()
-	pb.RegisterHerdServiceServer(s, NewServer(nil, "http://127.0.0.1:4000", 10))
+	pb.RegisterHerdServiceServer(s, srv)
 	go func() {
 		if err := s.Serve(lis); err != nil {
 			panic(err)
 		}
 	}()
+
+	t.Cleanup(func() {
+		s.Stop()
+		_ = lis.Close()
+	})
 }
 
 func bufDialer(context.Context, string) (net.Conn, error) {
@@ -32,7 +44,17 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 }
 
 func TestAcquireStream(t *testing.T) {
-	initGRPCServer()
+	factory := &testFactory{workers: []*testWorker{{id: "w1"}}}
+	pool, err := herd.New[*http.Client](factory, herd.WithAutoScale(1, 1))
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pool.Shutdown(context.Background())
+	})
+
+	initGRPCServer(t, NewServer(pool, "http://127.0.0.1:4000", 1))
+
 	ctx := context.Background()
 	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -73,4 +95,100 @@ func TestAcquireStream(t *testing.T) {
 	if err != io.EOF {
 		t.Errorf("Expected EOF after close, got %v", err)
 	}
+
+	if !waitForClosed(factory.workers[0], time.Second) {
+		t.Fatal("expected worker to be force-closed after stream EOF")
+	}
+}
+
+func TestAcquireStream_WithoutPool(t *testing.T) {
+	initGRPCServer(t, NewServer(nil, "http://127.0.0.1:4000", 1))
+
+	ctx := context.Background()
+	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewHerdServiceClient(conn)
+	stream, err := client.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("Failed to open Acquire stream: %v", err)
+	}
+
+	if err := stream.Send(&pb.AcquireRequest{WorkerType: "python"}); err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected recv error when pool is not configured")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %s", st.Code())
+	}
+}
+
+type testWorker struct {
+	id string
+
+	mu     sync.Mutex
+	closed bool
+
+	onCrash func(string)
+}
+
+func (w *testWorker) ID() string                    { return w.id }
+func (w *testWorker) Address() string               { return "http://127.0.0.1:19000" }
+func (w *testWorker) Client() *http.Client          { return &http.Client{} }
+func (w *testWorker) Healthy(context.Context) error { return nil }
+func (w *testWorker) OnCrash(fn func(string))       { w.onCrash = fn }
+func (w *testWorker) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	return nil
+}
+
+func (w *testWorker) isClosed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
+}
+
+type testFactory struct {
+	mu      sync.Mutex
+	workers []*testWorker
+	idx     int
+}
+
+func (f *testFactory) Spawn(context.Context) (herd.Worker[*http.Client], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.idx >= len(f.workers) {
+		// Return a closed-over worker to keep the pool alive in tests where
+		// maybeScaleUp can be triggered after KillSession.
+		w := &testWorker{id: "fallback"}
+		return w, nil
+	}
+	w := f.workers[f.idx]
+	f.idx++
+	return w, nil
+}
+
+func waitForClosed(w *testWorker, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if w.isClosed() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return w.isClosed()
 }

--- a/internal/daemon/grpc_server_test.go
+++ b/internal/daemon/grpc_server_test.go
@@ -19,7 +19,7 @@ var lis *bufconn.Listener
 func initGRPCServer() {
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer()
-	pb.RegisterHerdServiceServer(s, NewServer())
+	pb.RegisterHerdServiceServer(s, NewServer(nil, "http://127.0.0.1:4000", 10))
 	go func() {
 		if err := s.Serve(lis); err != nil {
 			panic(err)
@@ -56,8 +56,11 @@ func TestAcquireStream(t *testing.T) {
 		t.Fatalf("Failed to receive response: %v", err)
 	}
 
-	if resp.GetSessionId() != "stub-session-123" {
-		t.Errorf("Expected session_id stub-session-123, got %s", resp.GetSessionId())
+	if resp.GetSessionId() == "" {
+		t.Error("Expected non-empty session_id")
+	}
+	if got := resp.GetProxyAddress(); got != "http://127.0.0.1:4000" {
+		t.Errorf("Expected proxy_address http://127.0.0.1:4000, got %s", got)
 	}
 
 	// Close stream

--- a/internal/daemon/grpc_server_test.go
+++ b/internal/daemon/grpc_server_test.go
@@ -53,7 +53,7 @@ func TestAcquireStream(t *testing.T) {
 		_ = pool.Shutdown(context.Background())
 	})
 
-	initGRPCServer(t, NewServer(pool, "http://127.0.0.1:4000", 1))
+	initGRPCServer(t, NewServer(pool, "http://127.0.0.1:4000", 1, NewEventLogger("text", nil)))
 
 	ctx := context.Background()
 	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -102,7 +102,7 @@ func TestAcquireStream(t *testing.T) {
 }
 
 func TestAcquireStream_WithoutPool(t *testing.T) {
-	initGRPCServer(t, NewServer(nil, "http://127.0.0.1:4000", 1))
+	initGRPCServer(t, NewServer(nil, "http://127.0.0.1:4000", 1, NewEventLogger("text", nil)))
 
 	ctx := context.Background()
 	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -1,0 +1,266 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/herd-core/herd"
+	pb "github.com/herd-core/herd/proto/herd/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestDaemonIntegration_AcquireProxyAndCleanup(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream-ok"))
+	}))
+	defer backend.Close()
+
+	factory := &integrationFactory{upstreamAddress: backend.URL}
+	pool, err := herd.New[*http.Client](factory, herd.WithAutoScale(1, 1), herd.WithTTL(5*time.Minute))
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+	defer func() { _ = pool.Shutdown(context.Background()) }()
+
+	dataPlane := httptest.NewServer(NewDataPlaneHandler(pool, "/metrics"))
+	defer dataPlane.Close()
+
+	socketPath := fmt.Sprintf("/tmp/herd-it-%d.sock", time.Now().UnixNano())
+	grpcServer, cleanup := startIntegrationGRPCServer(t, socketPath, NewServer(pool, dataPlane.URL, 1, NewEventLogger("text", nil)))
+	defer cleanup()
+	defer grpcServer.Stop()
+
+	conn, err := dialUnixGRPC(socketPath)
+	if err != nil {
+		t.Fatalf("failed to dial control plane: %v", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewHerdServiceClient(conn)
+	stream, err := client.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("failed to open acquire stream: %v", err)
+	}
+
+	if err := stream.Send(&pb.AcquireRequest{WorkerType: "test"}); err != nil {
+		t.Fatalf("failed to send acquire request: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("failed to receive acquire response: %v", err)
+	}
+	if resp.GetSessionId() == "" {
+		t.Fatal("expected non-empty session id")
+	}
+	if got := resp.GetProxyAddress(); got != dataPlane.URL {
+		t.Fatalf("expected proxy address %q, got %q", dataPlane.URL, got)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, resp.GetProxyAddress()+"/", nil)
+	if err != nil {
+		t.Fatalf("build data-plane request: %v", err)
+	}
+	req.Header.Set(SessionHeader, resp.GetSessionId())
+
+	httpResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("data-plane request failed: %v", err)
+	}
+	body, _ := io.ReadAll(httpResp.Body)
+	httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from data-plane, got %d", httpResp.StatusCode)
+	}
+	if string(body) != "upstream-ok" {
+		t.Fatalf("unexpected data-plane body: %q", string(body))
+	}
+
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("close stream failed: %v", err)
+	}
+	_, err = stream.Recv()
+	if err != io.EOF {
+		t.Fatalf("expected EOF after CloseSend, got %v", err)
+	}
+
+	first := factory.firstWorker()
+	if first == nil {
+		t.Fatal("expected first worker to be available for cleanup assertion")
+	}
+	if !waitClosed(first, time.Second) {
+		t.Fatal("expected first worker to be closed after control stream EOF")
+	}
+}
+
+func TestDaemonIntegration_StatusHealthAndMetrics(t *testing.T) {
+	factory := &integrationFactory{upstreamAddress: "http://127.0.0.1:1"}
+	pool, err := herd.New[*http.Client](factory, herd.WithAutoScale(1, 1), herd.WithTTL(5*time.Minute))
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+	defer func() { _ = pool.Shutdown(context.Background()) }()
+
+	dataPlane := httptest.NewServer(NewDataPlaneHandler(pool, "/metrics"))
+	defer dataPlane.Close()
+
+	socketPath := fmt.Sprintf("/tmp/herd-it-%d.sock", time.Now().UnixNano())
+	grpcServer, cleanup := startIntegrationGRPCServer(t, socketPath, NewServer(pool, dataPlane.URL, 1, NewEventLogger("text", nil)))
+	defer cleanup()
+	defer grpcServer.Stop()
+
+	conn, err := dialUnixGRPC(socketPath)
+	if err != nil {
+		t.Fatalf("failed to dial control plane: %v", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewHerdServiceClient(conn)
+	statusResp, err := client.Status(context.Background(), &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("status rpc failed: %v", err)
+	}
+	if statusResp.GetMaxWorkers() != 1 {
+		t.Fatalf("expected max_workers=1, got %d", statusResp.GetMaxWorkers())
+	}
+
+	healthResp, err := http.Get(dataPlane.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("healthz request failed: %v", err)
+	}
+	healthBody, _ := io.ReadAll(healthResp.Body)
+	healthResp.Body.Close()
+	if healthResp.StatusCode != http.StatusOK || string(healthBody) != "ok" {
+		t.Fatalf("unexpected healthz response: status=%d body=%q", healthResp.StatusCode, string(healthBody))
+	}
+
+	metricsResp, err := http.Get(dataPlane.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("metrics request failed: %v", err)
+	}
+	metricsBody, _ := io.ReadAll(metricsResp.Body)
+	metricsResp.Body.Close()
+	metrics := string(metricsBody)
+
+	if metricsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected metrics status 200, got %d", metricsResp.StatusCode)
+	}
+	if !strings.Contains(metrics, "herd_total_workers") {
+		t.Fatalf("expected herd_total_workers in metrics output: %s", metrics)
+	}
+	if !strings.Contains(metrics, "herd_acquire_requests_total") {
+		t.Fatalf("expected lifecycle counters in metrics output: %s", metrics)
+	}
+}
+
+func startIntegrationGRPCServer(t *testing.T, socketPath string, srv pb.HerdServiceServer) (*grpc.Server, func()) {
+	t.Helper()
+
+	lis, err := ListenUnixSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket failed: %v", err)
+	}
+
+	s := grpc.NewServer()
+	pb.RegisterHerdServiceServer(s, srv)
+
+	go func() {
+		if err := s.Serve(lis); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			// Best-effort safety in tests: fail hard on unexpected serve errors.
+			panic(err)
+		}
+	}()
+
+	cleanup := func() {
+		_ = lis.Close()
+		_ = RemoveUnixSocket(socketPath)
+	}
+
+	return s, cleanup
+}
+
+func dialUnixGRPC(socketPath string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		"passthrough:///herd-integration",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return net.Dial("unix", socketPath)
+		}),
+	)
+}
+
+type integrationFactory struct {
+	upstreamAddress string
+	seq             atomic.Uint64
+
+	mu    sync.Mutex
+	first *integrationWorker
+}
+
+func (f *integrationFactory) Spawn(context.Context) (herd.Worker[*http.Client], error) {
+	w := &integrationWorker{id: fmt.Sprintf("it-worker-%d", f.seq.Add(1)), address: f.upstreamAddress}
+
+	f.mu.Lock()
+	if f.first == nil {
+		f.first = w
+	}
+	f.mu.Unlock()
+
+	return w, nil
+}
+
+func (f *integrationFactory) firstWorker() *integrationWorker {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.first
+}
+
+type integrationWorker struct {
+	id      string
+	address string
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func (w *integrationWorker) ID() string                    { return w.id }
+func (w *integrationWorker) Address() string               { return w.address }
+func (w *integrationWorker) Client() *http.Client          { return &http.Client{} }
+func (w *integrationWorker) Healthy(context.Context) error { return nil }
+func (w *integrationWorker) OnCrash(func(string))          {}
+
+func (w *integrationWorker) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	return nil
+}
+
+func waitClosed(w *integrationWorker, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		w.mu.Lock()
+		closed := w.closed
+		w.mu.Unlock()
+		if closed {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
+)
+
+const SessionHeader = "X-Session-ID"
+
+// ListenUnixSocket creates a UDS listener for the control plane.
+// It removes stale socket files before binding and applies owner-only perms.
+func ListenUnixSocket(path string) (net.Listener, error) {
+	if err := RemoveUnixSocket(path); err != nil {
+		return nil, fmt.Errorf("remove stale socket: %w", err)
+	}
+
+	lis, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen on unix socket %q: %w", path, err)
+	}
+
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, fmt.Errorf("chmod socket %q: %w", path, err)
+	}
+
+	return lis, nil
+}
+
+// RemoveUnixSocket removes a control-plane UDS file if it exists.
+func RemoveUnixSocket(path string) error {
+	err := os.Remove(path)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// NewDataPlaneHandler builds the HTTP data-plane mux.
+// - Proxy traffic is routed by X-Session-ID to session-affine workers.
+// - /healthz reports daemon liveness.
+// - telemetry metrics are exposed at metricsPath.
+func NewDataPlaneHandler(pool *herd.Pool[*http.Client], metricsPath string) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	mux.Handle(metricsPath, MetricsHandler(pool))
+
+	mux.Handle("/", proxy.NewReverseProxy(pool, func(r *http.Request) string {
+		return r.Header.Get(SessionHeader)
+	}))
+
+	return mux
+}
+
+// MetricsHandler exposes a small Prometheus-compatible text endpoint.
+func MetricsHandler(pool *herd.Pool[*http.Client]) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		stats := pool.Stats()
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+		_, _ = fmt.Fprintf(w,
+			"# HELP herd_total_workers Total workers tracked by herd pool.\n"+
+				"# TYPE herd_total_workers gauge\n"+
+				"herd_total_workers %d\n"+
+				"# HELP herd_available_workers Workers currently idle and available.\n"+
+				"# TYPE herd_available_workers gauge\n"+
+				"herd_available_workers %d\n"+
+				"# HELP herd_active_sessions Active sticky sessions.\n"+
+				"# TYPE herd_active_sessions gauge\n"+
+				"herd_active_sessions %d\n"+
+				"# HELP herd_inflight_acquires Acquire operations in progress.\n"+
+				"# TYPE herd_inflight_acquires gauge\n"+
+				"herd_inflight_acquires %d\n",
+			stats.TotalWorkers,
+			stats.AvailableWorkers,
+			stats.ActiveSessions,
+			stats.InflightAcquires,
+		)
+	})
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -66,6 +66,7 @@ func NewDataPlaneHandler(pool *herd.Pool[*http.Client], metricsPath string) http
 func MetricsHandler(pool *herd.Pool[*http.Client]) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		stats := pool.Stats()
+		life := SnapshotLifecycleCounters()
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
 		_, _ = fmt.Fprintf(w,
@@ -80,11 +81,27 @@ func MetricsHandler(pool *herd.Pool[*http.Client]) http.Handler {
 				"herd_active_sessions %d\n"+
 				"# HELP herd_inflight_acquires Acquire operations in progress.\n"+
 				"# TYPE herd_inflight_acquires gauge\n"+
-				"herd_inflight_acquires %d\n",
+				"herd_inflight_acquires %d\n"+
+				"# HELP herd_acquire_requests_total Total control-plane acquire requests received.\n"+
+				"# TYPE herd_acquire_requests_total counter\n"+
+				"herd_acquire_requests_total %d\n"+
+				"# HELP herd_acquire_failures_total Total acquire requests that failed.\n"+
+				"# TYPE herd_acquire_failures_total counter\n"+
+				"herd_acquire_failures_total %d\n"+
+				"# HELP herd_sessions_started_total Total sessions successfully started by control-plane streams.\n"+
+				"# TYPE herd_sessions_started_total counter\n"+
+				"herd_sessions_started_total %d\n"+
+				"# HELP herd_sessions_killed_total Total sessions force-killed during stream cleanup.\n"+
+				"# TYPE herd_sessions_killed_total counter\n"+
+				"herd_sessions_killed_total %d\n",
 			stats.TotalWorkers,
 			stats.AvailableWorkers,
 			stats.ActiveSessions,
 			stats.InflightAcquires,
+			life.AcquireRequests,
+			life.AcquireFailures,
+			life.SessionsStarted,
+			life.SessionsKilled,
 		)
 	})
 }

--- a/internal/daemon/runtime_policy.go
+++ b/internal/daemon/runtime_policy.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+)
+
+// EnforceRuntimePolicy validates platform support and emits guarantee warnings.
+// Linux runs with full guarantees. macOS is supported in reduced-guarantee mode.
+// Other operating systems fail fast at startup.
+func EnforceRuntimePolicy(goos string, logger *log.Logger) error {
+	switch goos {
+	case "linux":
+		logger.Println("runtime: linux detected; full worker parent-death guarantees enabled")
+		return nil
+	case "darwin":
+		logger.Println("WARNING: runtime: macOS detected; reduced guarantees mode enabled")
+		logger.Println("WARNING: runtime: kernel-level parent-death SIGKILL is unavailable on macOS")
+		logger.Println("WARNING: runtime: daemon crash may leave orphaned child processes; cleanup is best effort")
+		return nil
+	default:
+		return fmt.Errorf("unsupported platform %q: herd daemon supports linux (full guarantees) and macOS (reduced guarantees)", goos)
+	}
+}

--- a/internal/daemon/runtime_policy_test.go
+++ b/internal/daemon/runtime_policy_test.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestEnforceRuntimePolicy_Linux(t *testing.T) {
+	t.Parallel()
+
+	if err := EnforceRuntimePolicy("linux", log.New(io.Discard, "", 0)); err != nil {
+		t.Fatalf("expected linux to pass, got error: %v", err)
+	}
+}
+
+func TestEnforceRuntimePolicy_Darwin(t *testing.T) {
+	t.Parallel()
+
+	if err := EnforceRuntimePolicy("darwin", log.New(io.Discard, "", 0)); err != nil {
+		t.Fatalf("expected darwin to pass with warnings, got error: %v", err)
+	}
+}
+
+func TestEnforceRuntimePolicy_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	err := EnforceRuntimePolicy("windows", log.New(io.Discard, "", 0))
+	if err == nil {
+		t.Fatal("expected unsupported platform error")
+	}
+	if !strings.Contains(err.Error(), "unsupported platform") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1,13 +1,17 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/herd-core/herd"
 )
 
 func TestListenUnixSocket_RemovesStaleFile(t *testing.T) {
@@ -53,4 +57,59 @@ func TestNewDataPlaneHandler_Healthz(t *testing.T) {
 	if string(body) != "ok" {
 		t.Fatalf("expected body 'ok', got %q", string(body))
 	}
+}
+
+func TestMetricsHandler_ContainsLifecycleCounters(t *testing.T) {
+	t.Parallel()
+
+	RecordAcquireRequest()
+	RecordAcquireFailure()
+	RecordSessionStarted()
+	RecordSessionKilled()
+
+	pool := newMetricsPool(t)
+	h := MetricsHandler(pool)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	b := string(body)
+	if !strings.Contains(b, "herd_acquire_requests_total") {
+		t.Fatalf("expected acquire counter in metrics output, got: %s", b)
+	}
+	if !strings.Contains(b, "herd_sessions_killed_total") {
+		t.Fatalf("expected kill counter in metrics output, got: %s", b)
+	}
+}
+
+type metricsWorker struct{ id string }
+
+func (w *metricsWorker) ID() string                    { return w.id }
+func (w *metricsWorker) Address() string               { return "http://127.0.0.1:19001" }
+func (w *metricsWorker) Client() *http.Client          { return &http.Client{} }
+func (w *metricsWorker) Healthy(context.Context) error { return nil }
+func (w *metricsWorker) OnCrash(func(string))          {}
+func (w *metricsWorker) Close() error                  { return nil }
+
+type metricsFactory struct{}
+
+func (f *metricsFactory) Spawn(context.Context) (herd.Worker[*http.Client], error) {
+	return &metricsWorker{id: "m1"}, nil
+}
+
+func newMetricsPool(t *testing.T) *herd.Pool[*http.Client] {
+	t.Helper()
+	p, err := herd.New[*http.Client](&metricsFactory{}, herd.WithAutoScale(1, 1))
+	if err != nil {
+		t.Fatalf("failed creating metrics pool: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = p.Shutdown(context.Background())
+	})
+	return p
 }

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1,0 +1,56 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestListenUnixSocket_RemovesStaleFile(t *testing.T) {
+	t.Parallel()
+
+	path := fmt.Sprintf("/tmp/herd-%d.sock", time.Now().UnixNano())
+	_ = os.Remove(path)
+	if err := os.WriteFile(path, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	lis, err := ListenUnixSocket(path)
+	if err != nil {
+		t.Fatalf("ListenUnixSocket returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = RemoveUnixSocket(path)
+	})
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if perms := fi.Mode().Perm(); perms != 0o600 {
+		t.Fatalf("expected socket perms 0600, got %o", perms)
+	}
+}
+
+func TestNewDataPlaneHandler_Healthz(t *testing.T) {
+	t.Parallel()
+
+	h := NewDataPlaneHandler(nil, "/metrics")
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	if string(body) != "ok" {
+		t.Fatalf("expected body 'ok', got %q", string(body))
+	}
+}

--- a/internal/daemon/telemetry.go
+++ b/internal/daemon/telemetry.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+type EventLogger struct {
+	format string
+	logger *log.Logger
+}
+
+func NewEventLogger(format string, logger *log.Logger) *EventLogger {
+	if logger == nil {
+		logger = log.Default()
+	}
+	if format != "json" && format != "text" {
+		format = "text"
+	}
+	return &EventLogger{format: format, logger: logger}
+}
+
+func (l *EventLogger) Info(event string, fields map[string]any) {
+	l.emit("info", event, fields)
+}
+
+func (l *EventLogger) Warn(event string, fields map[string]any) {
+	l.emit("warn", event, fields)
+}
+
+func (l *EventLogger) Error(event string, fields map[string]any) {
+	l.emit("error", event, fields)
+}
+
+func (l *EventLogger) emit(level, event string, fields map[string]any) {
+	if fields == nil {
+		fields = map[string]any{}
+	}
+
+	if l.format == "json" {
+		record := map[string]any{
+			"ts":    time.Now().UTC().Format(time.RFC3339Nano),
+			"level": level,
+			"event": event,
+		}
+		for k, v := range fields {
+			record[k] = v
+		}
+		b, err := json.Marshal(record)
+		if err == nil {
+			l.logger.Print(string(b))
+			return
+		}
+	}
+
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := []string{"level=" + level, "event=" + event}
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, fields[k]))
+	}
+	l.logger.Print(strings.Join(parts, " "))
+}
+
+type lifecycleCounters struct {
+	acquireRequests atomic.Uint64
+	acquireFailures atomic.Uint64
+	sessionsStarted atomic.Uint64
+	sessionsKilled  atomic.Uint64
+}
+
+var counters lifecycleCounters
+
+func RecordAcquireRequest() { counters.acquireRequests.Add(1) }
+func RecordAcquireFailure() { counters.acquireFailures.Add(1) }
+func RecordSessionStarted() { counters.sessionsStarted.Add(1) }
+func RecordSessionKilled()  { counters.sessionsKilled.Add(1) }
+
+type LifecycleSnapshot struct {
+	AcquireRequests uint64
+	AcquireFailures uint64
+	SessionsStarted uint64
+	SessionsKilled  uint64
+}
+
+func SnapshotLifecycleCounters() LifecycleSnapshot {
+	return LifecycleSnapshot{
+		AcquireRequests: counters.acquireRequests.Load(),
+		AcquireFailures: counters.acquireFailures.Load(),
+		SessionsStarted: counters.sessionsStarted.Load(),
+		SessionsKilled:  counters.sessionsKilled.Load(),
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,10 +60,10 @@ nav:
     # - Installation: go/install.md
     # - The Pool Engine: go/pool.md
     - Worker Interfaces: go/workers.md
-#  - gRPC Daemon:
-#    - Installation: daemon/install.md
-#    - CLI Reference: daemon/cli.md
-#    - Unix Domain Sockets: daemon/uds.md
+  - gRPC Daemon:
+    - Installation: daemon/install.md
+    - CLI Reference: daemon/cli.md
+    - Unix Domain Sockets: daemon/uds.md
 #  - Language SDKs:
 #    - Python: sdks/python.md
 #    - Elixir: sdks/elixir.md

--- a/pool.go
+++ b/pool.go
@@ -578,6 +578,7 @@ func (p *Pool[C]) Shutdown(ctx context.Context) error {
 	for _, w := range workers {
 		if err := w.Close(); err != nil {
 			log.Printf("[pool] Shutdown: error closing worker %s: %v", w.ID(), err)
+			return err
 		}
 	}
 	log.Println("[pool] shutdown complete")

--- a/pool.go
+++ b/pool.go
@@ -397,6 +397,40 @@ func (p *Pool[C]) releaseConn(sessionID string) {
 	p.mu.Unlock()
 }
 
+// KillSession forcefully tears down the worker pinned to sessionID.
+// This is used by daemon control-plane EOF cleanup to prevent orphaned
+// stateful workers when a client disconnects unexpectedly.
+// If the session does not exist, KillSession returns nil.
+func (p *Pool[C]) KillSession(sessionID string) error {
+	p.mu.Lock()
+	w, err := p.registry.Get(context.Background(), sessionID)
+	if err != nil {
+		p.mu.Unlock()
+		return fmt.Errorf("herd: KillSession(%q): registry lookup failed: %w", sessionID, err)
+	}
+	if w == nil {
+		delete(p.activeConns, sessionID)
+		delete(p.lastAccessed, sessionID)
+		p.mu.Unlock()
+		return nil
+	}
+
+	_ = p.registry.Delete(context.Background(), sessionID)
+	delete(p.activeConns, sessionID)
+	delete(p.lastAccessed, sessionID)
+	p.mu.Unlock()
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("herd: KillSession(%q): close worker %s: %w", sessionID, w.ID(), err)
+	}
+
+	p.removeWorker(w)
+	p.maybeScaleUp()
+
+	log.Printf("[pool] KillSession(%q): worker %s force-terminated", sessionID, w.ID())
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // onCrash — called by processWorker.monitor on unexpected exit
 // ---------------------------------------------------------------------------

--- a/pool_test.go
+++ b/pool_test.go
@@ -45,9 +45,9 @@ type stubWorker struct {
 
 type stubClient struct{}
 
-func (w *stubWorker) ID() string          { return w.id }
-func (w *stubWorker) Address() string     { return "http://127.0.0.1:9999" }
-func (w *stubWorker) Client() *stubClient { return &stubClient{} }
+func (w *stubWorker) ID() string              { return w.id }
+func (w *stubWorker) Address() string         { return "http://127.0.0.1:9999" }
+func (w *stubWorker) Client() *stubClient     { return &stubClient{} }
 func (w *stubWorker) OnCrash(fn func(string)) {}
 func (w *stubWorker) Healthy(_ context.Context) error {
 	w.mu.Lock()
@@ -185,6 +185,35 @@ func TestSameSessionSingleflight(t *testing.T) {
 	// Verify one session is pinned
 	if n := pool.registry.Len(); n != 1 {
 		t.Errorf("expected 1 session pinned, got %d", n)
+	}
+}
+
+func TestKillSession_ForceTerminatesWorker(t *testing.T) {
+	w1 := &stubWorker{id: "worker-1"}
+	pool := newTestPool(t, w1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sess, err := pool.Acquire(ctx, "session-kill")
+	if err != nil {
+		t.Fatalf("Acquire returned unexpected error: %v", err)
+	}
+
+	if err := pool.KillSession(sess.ID); err != nil {
+		t.Fatalf("KillSession returned error: %v", err)
+	}
+
+	w1.mu.Lock()
+	closed := w1.closed
+	w1.mu.Unlock()
+	if !closed {
+		t.Fatal("expected worker to be closed after KillSession")
+	}
+
+	stats := pool.Stats()
+	if stats.ActiveSessions != 0 {
+		t.Fatalf("expected 0 active sessions after KillSession, got %d", stats.ActiveSessions)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new CLI structure for the `herd` daemon, transitioning from a simple main function to a modular, command-based interface using the `cobra` library. It adds a `start` command with configurable flags, sets up graceful shutdown handling, and initializes the process pool with placeholders for future configuration.

**CLI Framework Integration and Command Structure**

* Introduced the `cobra` library and created a new `rootCmd` in `cmd/herd/root.go`, providing a structured CLI entry point for the `herd` daemon. [[1]](diffhunk://#diff-ac242029a597bfbb3821bec2d2ab88f120ce78a6bb60af93c2039677de2f1d25R1-R16) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-R8)
* Refactored `main.go` to delegate execution to the new `Execute()` function, handling errors and exit codes appropriately.

**Start Command and Daemon Lifecycle Management**

* Added a `start` subcommand in `cmd/herd/start.go` that initializes the daemon, sets up signal handling for graceful shutdown, and configures the HTTP and gRPC endpoints via CLI flags.
* Implemented process pool initialization using a placeholder factory and ensured proper cleanup and shutdown logging for the pool lifecycle.

**Dependency Management**

* Updated `go.mod` to include `cobra` and related dependencies required for the new CLI structure.