### PR TITLE
updating from hackstrix/ to herd-core/

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This invariant transforms stateful binaries (like Browsers, LLMs, or REPLs) into
 ## 📦 Installation
 
 ```bash
-go get github.com/hackstrix/herd
+go get github.com/herd-core/herd
 ```
 
 ---
@@ -72,8 +72,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hackstrix/herd"
-	"github.com/hackstrix/herd/proxy"
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
 )
 
 func main() {
@@ -155,8 +155,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hackstrix/herd"
-	"github.com/hackstrix/herd/proxy"
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
 )
 
 func main() {
@@ -247,7 +247,7 @@ Herd is built around three core interfaces:
 ```go
 import (
     "fmt"
-    "github.com/hackstrix/herd"
+    "github.com/herd-core/herd"
 )
 
 stats := pool.Stats()

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hackstrix/herd"
-	"github.com/hackstrix/herd/proxy"
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
 )
 
 func main() {
@@ -103,8 +103,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hackstrix/herd"
-	"github.com/hackstrix/herd/proxy"
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
 )
 
 func main() {

--- a/examples/ollama/go.mod
+++ b/examples/ollama/go.mod
@@ -1,7 +1,7 @@
-module github.com/hackstrix/herd/examples/ollama
+module github.com/herd-core/herd/examples/ollama
 
 go 1.24
 
-require github.com/hackstrix/herd v0.1.2
+require github.com/herd-core/herd v0.1.2
 
-replace github.com/hackstrix/herd => ../..
+replace github.com/herd-core/herd => ../..

--- a/examples/ollama/main.go
+++ b/examples/ollama/main.go
@@ -35,8 +35,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hackstrix/herd"
-	"github.com/hackstrix/herd/proxy"
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
 )
 
 func main() {

--- a/examples/playwright/go.mod
+++ b/examples/playwright/go.mod
@@ -1,7 +1,7 @@
-module github.com/hackstrix/herd/examples/playwright
+module github.com/herd-core/herd/examples/playwright
 
 go 1.24
 
-require github.com/hackstrix/herd v0.1.2
+require github.com/herd-core/herd v0.1.2
 
-replace github.com/hackstrix/herd => ../..
+replace github.com/herd-core/herd => ../..

--- a/examples/playwright/main.go
+++ b/examples/playwright/main.go
@@ -22,8 +22,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hackstrix/herd"
-	"github.com/hackstrix/herd/proxy"
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/proxy"
 )
 
 func main() {

--- a/factory_cgroup_test.go
+++ b/factory_cgroup_test.go
@@ -7,7 +7,7 @@ package herd
 import (
 	"testing"
 
-	"github.com/hackstrix/herd/internal/core"
+	"github.com/herd-core/herd/internal/core"
 )
 
 func TestNewProcessFactory_DefaultCgroupPIDs(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hackstrix/herd
+module github.com/herd-core/herd
 
 go 1.24.0
 

--- a/internal/daemon/grpc_server.go
+++ b/internal/daemon/grpc_server.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 
-	pb "github.com/hackstrix/herd/proto/herd/v1"
+	pb "github.com/herd-core/herd/proto/herd/v1"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 

--- a/internal/daemon/grpc_server_test.go
+++ b/internal/daemon/grpc_server_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"testing"
 
-	pb "github.com/hackstrix/herd/proto/herd/v1"
+	pb "github.com/herd-core/herd/proto/herd/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"

--- a/pool.go
+++ b/pool.go
@@ -56,7 +56,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hackstrix/herd/observer"
+	"github.com/herd-core/herd/observer"
 )
 
 // ---------------------------------------------------------------------------

--- a/process_worker_factory.go
+++ b/process_worker_factory.go
@@ -42,8 +42,9 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"github.com/hackstrix/herd/internal/core"
 	"time"
+
+	"github.com/herd-core/herd/internal/core"
 )
 
 var ErrWorkerDead = errors.New("worker process has died")

--- a/proto/herd/v1/herd.pb.go
+++ b/proto/herd/v1/herd.pb.go
@@ -221,7 +221,7 @@ const file_proto_herd_v1_herd_proto_rawDesc = "" +
 	"maxWorkers2\x8a\x01\n" +
 	"\vHerdService\x12@\n" +
 	"\aAcquire\x12\x17.herd.v1.AcquireRequest\x1a\x18.herd.v1.AcquireResponse(\x010\x01\x129\n" +
-	"\x06Status\x12\x16.google.protobuf.Empty\x1a\x17.herd.v1.StatusResponseB)Z'github.com/hackstrix/herd/proto/herd/v1b\x06proto3"
+	"\x06Status\x12\x16.google.protobuf.Empty\x1a\x17.herd.v1.StatusResponseB)Z'github.com/herd-core/herd/proto/herd/v1b\x06proto3"
 
 var (
 	file_proto_herd_v1_herd_proto_rawDescOnce sync.Once

--- a/proto/herd/v1/herd.proto
+++ b/proto/herd/v1/herd.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package herd.v1;
 
-option go_package = "github.com/hackstrix/herd/proto/herd/v1";
+option go_package = "github.com/herd-core/herd/proto/herd/v1";
 
 import "google/protobuf/empty.proto";
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -50,7 +50,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	"github.com/hackstrix/herd"
+	"github.com/herd-core/herd"
 )
 
 // ---------------------------------------------------------------------------

--- a/scripts/pivot_factory.sh
+++ b/scripts/pivot_factory.sh
@@ -29,9 +29,9 @@ sed -i '' 's/defaultNamespaceCloneFlags/DefaultNamespaceCloneFlags/g' internal/c
 
 # Update process_worker_factory.go to use core. prefixed Sandbox methods
 # Add import
-sed -i '' 's|"sync/atomic"|"sync/atomic"\n\t"github.com/hackstrix/herd/internal/core"|g' process_worker_factory.go
-# Wait, previous fix added "github.com/hackstrix/herd" to process_worker_factory.go, remove it or replace it!
-sed -i '' 's|"github.com/hackstrix/herd"|"github.com/hackstrix/herd/internal/core"|g' process_worker_factory.go
+sed -i '' 's|"sync/atomic"|"sync/atomic"\n\t"github.com/herd-core/herd/internal/core"|g' process_worker_factory.go
+# Wait, previous fix added "github.com/herd-core/herd" to process_worker_factory.go, remove it or replace it!
+sed -i '' 's|"github.com/herd-core/herd"|"github.com/herd-core/herd/internal/core"|g' process_worker_factory.go
 
 echo "✅ Pivot completed. Checking build..."
 go build ./...

--- a/scripts/refactor_core.sh
+++ b/scripts/refactor_core.sh
@@ -17,7 +17,7 @@ if [ -d "internal/observer" ]; then
 fi
 
 # Revert pool.go import back to original for observer
-sed -i '' 's|"github.com/hackstrix/herd/internal/observer"|"github.com/hackstrix/herd/observer"|g' pool.go
+sed -i '' 's|"github.com/herd-core/herd/internal/observer"|"github.com/herd-core/herd/observer"|g' pool.go
 
 # Create internal/core
 mkdir -p internal/core


### PR DESCRIPTION
This pull request updates the project's module path and all related import statements from `github.com/hackstrix/herd` to `github.com/herd-core/herd`. This change is applied consistently across the main module, documentation, example projects, internal code, and scripts to ensure the codebase references the new repository location.

**Module path and import updates:**

* Updated the main Go module path in `go.mod` and all submodules (e.g., `examples/ollama/go.mod`, `examples/playwright/go.mod`) to use `github.com/herd-core/herd` instead of `github.com/hackstrix/herd`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1) [[2]](diffhunk://#diff-673ad10dcbce475c0459d5eef62c2d452c70a817cd1c7edc41a6b92a148fd7f6L1-R7) [[3]](diffhunk://#diff-84aedc177e6440abb6d052c3c02ec75066b235f609dd3250a79a4575e8891eeeL1-R7)
* Replaced all import statements throughout the codebase, documentation (`README.md`, `docs/intro/quickstart.md`), and example files to reference `github.com/herd-core/herd` and its subpackages. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R76) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R159) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L250-R250) [[5]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL23-R24) [[6]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL106-R107) [[7]](diffhunk://#diff-dd35bcb8e48f587ea5a480919438466db2ee3167c2a8194fe9a39eb20e2c9bd4L38-R39) [[8]](diffhunk://#diff-6196e4e2dc65250cbbea9b9cfc7a7765ebb97304fffeffb68726c2016b168c0fL25-R26) [[9]](diffhunk://#diff-6d082769b4f267d2b7fb9ac572d55aa86cd7ce09cc151c6b27d53c571903e3c9L10-R10) [[10]](diffhunk://#diff-a4f6f19b50648234398a07f9d91cf7bb9b5aaa3372509ca92dd304f30266c963L8-R8) [[11]](diffhunk://#diff-0185cdd2442a53ad15902fd6a196cde0cb4dbb5b4296dfbbadc6e145bb24a0c8L9-R9) [[12]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L59-R59) [[13]](diffhunk://#diff-d86d7bc9f8960d3714f3534ca33f97885dd43de1236f7832c643a43cd43967d9L45-R47) [[14]](diffhunk://#diff-1d74870266949f1927a500e5f0002617239d3e3cd9bcceee6be014738e5e0f2bL53-R53)
* Updated protocol buffer Go package options and generated code to use the new module path. [[1]](diffhunk://#diff-90a0e9bdbfcd461b96a96bab3062fbcfb791055e89b18c5cac7bef3ea6eca2e1L5-R5) [[2]](diffhunk://#diff-dc7820df3d07723cbd91ed46fc1a2e4330e0138b858e9efde168017a8c6a96a0L224-R224)

**Script and tooling adjustments:**

* Modified build and refactoring scripts to ensure they update import paths and references to the new module location. [[1]](diffhunk://#diff-33793dbb066b7a69b75239f2ce2bf5d6f2bb665182cceab8622aaee7c340d0b2L32-R34) [[2]](diffhunk://#diff-c05e78fb47eeaf3a14e35d9827d64cec8aec5936a608d4bc6fd42aa431c39575L20-R20)

These changes ensure consistency and proper functioning of the codebase after moving to the new repository location.