### PR TITLE
updating the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,22 +127,32 @@ sudo ./herd start --config ./herd.yaml
 
 ### 3. Usage
 
-First, use a Herd client (which connects to the UDS Control Plane) to acquire a session. This establishes a stream that acts as a dead-man's switch. Then, connect your tools through the HTTP Data Plane proxy using the returned `session_id`.
+First, explicitly install the `herd-client` package to communicate with the daemon:
+
+```bash
+pip install herd-client
+```
+
+Next, use a Herd client (which connects to the UDS Control Plane) to acquire a session. This establishes a stream that acts as a dead-man's switch. Then, connect your tools through the HTTP Data Plane proxy using the allocated session ID and proxy URL.
 
 ```python
 import asyncio
 from playwright.async_api import async_playwright
-from herd_client import HerdClient
+from herd import AsyncClient
 
 async def main():
-    # 1. Acquire session via Control Plane (UDS dead-man's switch)
-    with HerdClient("/tmp/herd.sock") as client:
-        session = client.acquire()
+    # 1. Connect to the Herd daemon via the Control Plane socket
+    client = AsyncClient("unix:///tmp/herd.sock")
+    
+    # 2. Acquire a session (holds a dead-man's switch via heartbeat)
+    async with client.acquire(worker_type="playwright-worker") as session:
+        print(f"Acquired worker session: {session.id}")
 
-        # 2. Connect to Data Plane proxy using the allocated session ID
+        # 3. Connect to the Data Plane proxy using the exact assigned session proxy_url
         async with async_playwright() as p:
+            # We pass the X-Session-ID header so the Proxy maps us to the correct worker
             browser = await p.chromium.connect(
-                "ws://127.0.0.1:8080/", 
+                f"ws://127.0.0.1:8080/", 
                 headers={"X-Session-ID": session.id}
             )
             
@@ -191,19 +201,26 @@ sudo ./herd start --config ./herd.yaml
 
 ### 3. Usage
 
-Just like the Playwright example, you first acquire a session over the UDS Control Plane, and then send your HTTP traffic to the Data Plane using that Session ID. Here is how that looks in Python.
+Just like the Playwright example, you first install `herd-client`. We'll use the easy-to-read synchronous API for this example so you can easily drop it into standard scripts.
+
+```bash
+pip install herd-client
+```
 
 ```python
 import requests
-from herd_client import HerdClient
+from herd import Client
 
-# 1. Acquire session via Control Plane (UDS dead-man's switch)
-with HerdClient("/tmp/herd.sock") as client:
-    session = client.acquire()
+# 1. Connect to the Herd daemon via the Control Plane socket
+client = Client("unix:///tmp/herd.sock")
 
-    # 2. Send API requests to the Data Plane proxy
+# 2. Acquire session via Control Plane (context manager handles background heartbeats)
+with client.acquire(worker_type="ollama") as session:
+    print(f"Acquired worker session: {session.id}")
+
+    # 3. Send API requests directly to this worker via the Session Proxy URL
     response = requests.post(
-        "http://127.0.0.1:8080/api/chat",
+        f"{session.proxy_url}/api/chat",
         headers={"X-Session-ID": session.id},
         json={
             "model": "llama3",

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -37,22 +37,32 @@ sudo herd start --config ./herd.yaml
 
 ### 3. Usage
 
-First, use a Herd client (which connects to the UDS Control Plane) to acquire a session. This establishes a stream that acts as a dead-man's switch. Then, connect your tools through the HTTP Data Plane proxy using the returned `session_id`.
+First, explicitly install the `herd-client` package to communicate with the daemon:
+
+```bash
+pip install herd-client
+```
+
+Next, use a Herd client (which connects to the UDS Control Plane) to acquire a session. This establishes a stream that acts as a dead-man's switch. Then, connect your tools through the HTTP Data Plane proxy using the allocated session ID and proxy URL.
 
 ```python
 import asyncio
 from playwright.async_api import async_playwright
-from herd_client import HerdClient
+from herd import AsyncClient
 
 async def main():
-    # 1. Acquire session via Control Plane (UDS dead-man's switch)
-    with HerdClient("/tmp/herd.sock") as client:
-        session = client.acquire()
+    # 1. Connect to the Herd daemon via the Control Plane socket
+    client = AsyncClient("unix:///tmp/herd.sock")
+    
+    # 2. Acquire a session (holds a dead-man's switch via heartbeat)
+    async with client.acquire(worker_type="playwright-worker") as session:
+        print(f"Acquired worker session: {session.id}")
 
-        # 2. Connect to Data Plane proxy using the allocated session ID
+        # 3. Connect to the Data Plane proxy using the exact assigned session proxy_url
         async with async_playwright() as p:
+            # We pass the X-Session-ID header so the Proxy maps us to the correct worker
             browser = await p.chromium.connect(
-                "ws://127.0.0.1:8080/", 
+                f"ws://127.0.0.1:8080/", 
                 headers={"X-Session-ID": session.id}
             )
             
@@ -101,19 +111,26 @@ sudo herd start --config ./herd.yaml
 
 ### 3. Usage
 
-Just like the Playwright example, you first acquire a session over the UDS Control Plane, and then send your HTTP traffic to the Data Plane using that Session ID. Here is how that looks in Python.
+Just like the Playwright example, you first install `herd-client`. We'll use the easy-to-read synchronous API for this example so you can easily drop it into standard scripts.
+
+```bash
+pip install herd-client
+```
 
 ```python
 import requests
-from herd_client import HerdClient
+from herd import Client
 
-# 1. Acquire session via Control Plane (UDS dead-man's switch)
-with HerdClient("/tmp/herd.sock") as client:
-    session = client.acquire()
+# 1. Connect to the Herd daemon via the Control Plane socket
+client = Client("unix:///tmp/herd.sock")
 
-    # 2. Send API requests to the Data Plane proxy
+# 2. Acquire session via Control Plane (context manager handles background heartbeats)
+with client.acquire(worker_type="ollama") as session:
+    print(f"Acquired worker session: {session.id}")
+
+    # 3. Send API requests directly to this worker via the Session Proxy URL
     response = requests.post(
-        "http://127.0.0.1:8080/api/chat",
+        f"{session.proxy_url}/api/chat",
         headers={"X-Session-ID": session.id},
         json={
             "model": "llama3",

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -1,1 +1,68 @@
 # Python SDK
+
+The official Herd Python client offers a robust, production-ready interface for interacting with the Herd daemon. It supports both fully synchronous and highly concurrent `asyncio` patterns.
+
+## Installation
+
+Install the library directly from PyPI:
+
+```bash
+pip install herd-client
+```
+
+## Quick Start (Synchronous)
+
+For standard scripts, data processing tools, or non-async web frameworks, use the synchronous `Client`. Using it as a context manager ensures the background heartbeat process automatically starts and stops safely.
+
+```python
+import requests
+from herd import Client
+
+# Note: The transport can be unix:/// or a standard tcp endpoint
+client = Client("unix:///tmp/herd.sock")
+
+# Acquire a dedicated worker process for this block
+with client.acquire(worker_type="healthworker", timeout=15) as session:
+    print(f"Connected to worker: {session.id}")
+    
+    # The proxy URL handles dynamic routing directly to that specific worker
+    resp = requests.post(
+        f"{session.proxy_url}/health",
+        headers={"X-Session-ID": session.id}
+    )
+    
+    print(resp.json())
+```
+
+## Quick Start (Asyncio)
+
+For high-performance gateways, FastAPI integrations, or asynchronous tools like Playwright, use the `AsyncClient`.
+
+```python
+import asyncio
+import httpx
+from herd import AsyncClient
+
+async def main():
+    client = AsyncClient("unix:///tmp/herd.sock")
+    
+    async with client.acquire(worker_type="playwright-worker") as session:
+        print(f"Connected to worker: {session.id}")
+        
+        async with httpx.AsyncClient() as http:
+            resp = await http.post(
+                f"{session.proxy_url}/health",
+                headers={"X-Session-ID": session.id}
+            )
+            print(resp.json())
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Under the Hood
+
+When you call `acquire()` and enter the `with` block:
+1. The client opens a gRPC stream over the Control Plane and formally registers a session with the daemon's `LifecycleManager`.
+2. A background execution thread/task is automatically spun up that sends a `PING` every few seconds to keep the process alive.
+3. If your script crashes, the context manager drops the heartbeat, and the daemon's `Reaper` immediately assassinates the zombie worker process, guaranteeing zero container or dependency leaks.


### PR DESCRIPTION
This pull request updates the Python SDK documentation and quickstart guides to improve clarity, modernize usage examples, and introduce a new dedicated SDK documentation page. The changes focus on making it easier for users to install and use the `herd-client` package, providing both synchronous and asynchronous examples, and explaining the session management model in more detail.

**Documentation improvements and modernization:**

* Added a new `docs/sdks/python.md` page with detailed installation instructions, quick start examples for both synchronous (`Client`) and asynchronous (`AsyncClient`) usage, and an explanation of the session lifecycle and heartbeat mechanism.
* Updated the Playwright and HTTP usage sections in both `README.md` and `docs/intro/quickstart.md` to:
  - Explicitly instruct users to install the `herd-client` package before usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R155) [[2]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL40-R65) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R223) [[4]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL104-R133)
  - Replace deprecated `herd_client.HerdClient` imports with the new `herd.Client` and `herd.AsyncClient` classes, and update example code to use the new API. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R155) [[2]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL40-R65) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R223) [[4]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL104-R133)
  - Clarify the use of `session.proxy_url` for connecting to the correct worker instance and update comments to explain the importance of the `X-Session-ID` header. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R155) [[2]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL40-R65) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R223) [[4]](diffhunk://#diff-d1881d3ad9ca8e8dd6a81c6730cbde12e7be3b7f9da0fc5451e33ea41346714bL104-R133)