### PR TITLE
Feat/idle targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ worker:
   command: ["npx", "playwright", "run-server", "--port", "{{.Port}}", "--host", "127.0.0.1"]
 
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 5
   ttl: 15m
   worker_reuse: false # CRITICAL: Never share browsers between users
@@ -183,7 +183,7 @@ worker:
     - "OLLAMA_HOST=127.0.0.1:{{.Port}}"
 
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 10
   ttl: 10m
   worker_reuse: true
@@ -241,7 +241,7 @@ with client.acquire(worker_type="ollama") as session:
 | `network.data_bind` | IP:Port for the Data Plane HTTP proxy (e.g., `127.0.0.1:8080`). |
 | `worker.command` | The subprocess command and args to spawn (e.g., `["npx", "playwright", "run-server"]`). |
 | `worker.env` | Environment variables to inject (`FOO=bar`). Supports templating like `{{.Port}}`. |
-| `resources.min_workers` / `max_workers` | Sets the auto-scaling floor and ceiling for the process fleet. |
+| `resources.target_idle` / `max_workers` | Sets the auto-scaling floor and ceiling for the process fleet. |
 | `resources.ttl` | Max idle time for a session before the worker is automatically evicted (e.g. `15m`). |
 | `resources.worker_reuse` | Whether to recycle workers for new sessions or kill them when TTL expires. |
 | `resources.health_interval` | How often to poll worker `/healthz` endpoints. |

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -177,9 +177,8 @@ func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {
 	}
 
 	return herd.New(factory,
-		herd.WithAutoScale(cfg.Resources.MinWorkers, cfg.Resources.MaxWorkers),
+		herd.WithAutoScale(cfg.Resources.TargetIdle, cfg.Resources.MaxWorkers),
 		herd.WithTTL(cfg.Resources.IdleTTLDuration()),
 		herd.WithHealthInterval(cfg.Resources.HealthIntervalDuration()),
-		herd.WithWorkerReuse(cfg.Resources.WorkerReuse),
 	)
 }

--- a/docs/daemon/cli.md
+++ b/docs/daemon/cli.md
@@ -30,7 +30,7 @@ worker:
   start_health_check_delay: 1s
 
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 4
   memory_limit_mb: 512
   cpu_limit_cores: 1
@@ -55,7 +55,7 @@ telemetry:
 | `worker.env` | Environment variables to inject (`FOO=bar`). Supports templating like `{{.Port}}`. |
 | `worker.health_path` | HTTP path polled for liveness. |
 | `worker.start_timeout` | Time allowed for worker to become healthy. |
-| `resources.min_workers` / `max_workers` | Sets the auto-scaling floor and ceiling for the process fleet. |
+| `resources.target_idle` / `max_workers` | Sets the auto-scaling floor and ceiling for the process fleet. |
 | `resources.ttl` | Max idle time for a session before the worker is automatically evicted (e.g. `15m`). |
 | `resources.worker_reuse` | Whether to recycle workers for new sessions or kill them when TTL expires. |
 | `resources.health_interval` | How often to poll worker health endpoints. |

--- a/docs/daemon/install.md
+++ b/docs/daemon/install.md
@@ -26,7 +26,7 @@ worker:
 	start_health_check_delay: 1s
 
 resources:
-	min_workers: 1
+	target_idle: 1
 	max_workers: 4
 	memory_limit_mb: 512
 	cpu_limit_cores: 1

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -18,7 +18,7 @@ worker:
   command: ["npx", "playwright", "run-server", "--port", "{{.Port}}", "--host", "127.0.0.1"]
 
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 5
   ttl: 15m
   worker_reuse: false # CRITICAL: Never share browsers between users
@@ -93,7 +93,7 @@ worker:
     - "OLLAMA_HOST=127.0.0.1:{{.Port}}"
 
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 10
   ttl: 10m
   worker_reuse: true

--- a/examples/library/ollama/main.go
+++ b/examples/library/ollama/main.go
@@ -40,7 +40,7 @@ import (
 )
 
 func main() {
-	minWorkers := flag.Int("min", 1, "minimum ollama workers kept alive")
+	targetIdle := flag.Int("min", 1, "minimum ollama workers kept alive")
 	maxWorkers := flag.Int("max", 5, "maximum concurrent ollama workers")
 	port := flag.Int("port", 8080, "gateway listen port")
 	modelsDir := flag.String("models", "/Users/sankalpnarula/.ollama/models", "shared models directory (read-only mount)")
@@ -67,7 +67,7 @@ func main() {
 
 	// ── Pool ───────────────────────────────────────────────────────────────
 	pool, err := herd.New(factory,
-		herd.WithAutoScale(*minWorkers, *maxWorkers),
+		herd.WithAutoScale(*targetIdle, *maxWorkers),
 		herd.WithTTL(*ttl),
 		herd.WithCrashHandler(func(agentID string) {
 			// An ollama worker crashed while serving an agent.
@@ -127,7 +127,7 @@ func main() {
 
 	addr := fmt.Sprintf(":%d", *port)
 	log.Printf("[ollama-gateway] listening on %s  (min=%d max=%d ttl=%s models=%s)",
-		addr, *minWorkers, *maxWorkers, *ttl, *modelsDir)
+		addr, *targetIdle, *maxWorkers, *ttl, *modelsDir)
 	log.Fatal(http.ListenAndServe(addr, mux))
 }
 

--- a/examples/library/playwright/main.go
+++ b/examples/library/playwright/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	minWorkers := flag.Int("min", 1, "minimum playwright workers kept alive")
+	targetIdle := flag.Int("min", 1, "minimum playwright workers kept alive")
 	maxWorkers := flag.Int("max", 5, "maximum concurrent playwright workers")
 	port := flag.Int("port", 8080, "gateway listen port")
 	ttl := flag.Duration("ttl", 15*time.Minute, "idle session TTL before the worker is reclaimed")
@@ -53,7 +53,7 @@ func main() {
 	// To make a bulletproof multi-tenant tool and avoid shared fate, state leaks,
 	// and resource throttling, Herd spawns a fresh Playwright server per Session ID.
 	pool, err := herd.New(factory,
-		herd.WithAutoScale(*minWorkers, *maxWorkers),
+		herd.WithAutoScale(*targetIdle, *maxWorkers),
 		herd.WithTTL(*ttl),
 		herd.WithCrashHandler(func(sessionID string) {
 			log.Printf("[ALERT] playwright worker for session %q crashed", sessionID)
@@ -106,6 +106,6 @@ func main() {
 
 	addr := fmt.Sprintf(":%d", *port)
 	log.Printf("[playwright-gateway] listening on %s  (min=%d max=%d ttl=%s)",
-		addr, *minWorkers, *maxWorkers, *ttl)
+		addr, *targetIdle, *maxWorkers, *ttl)
 	log.Fatal(http.ListenAndServe(addr, mux))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ func (w WorkerConfig) StartHealthCheckDelayDuration() time.Duration {
 }
 
 type ResourceConfig struct {
-	MinWorkers     int     `yaml:"min_workers"`
+	TargetIdle     int     `yaml:"target_idle"`
 	MaxWorkers     int     `yaml:"max_workers"`
 	MemoryLimitMB  int64   `yaml:"memory_limit_mb"`
 	CPULimitCores  float64 `yaml:"cpu_limit_cores"`
@@ -56,7 +56,6 @@ type ResourceConfig struct {
 	HeartbeatGrace string  `yaml:"heartbeat_grace"` // Max time without ping
 	DataTimeout    string  `yaml:"data_timeout"`    // Max time for HTTP request
 	HealthInterval string  `yaml:"health_interval"`
-	WorkerReuse    bool    `yaml:"worker_reuse"`
 
 	// InsecureSandbox enables reduced sandboxing for local development.
 	// This should not be enabled in production.
@@ -178,11 +177,11 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("worker.env[%d] must be in KEY=VALUE format", i)
 		}
 	}
-	if c.Resources.MinWorkers < 1 {
-		return fmt.Errorf("resources.min_workers must be >= 1")
+	if c.Resources.TargetIdle < 1 {
+		return fmt.Errorf("resources.target_idle must be >= 1")
 	}
-	if c.Resources.MaxWorkers < c.Resources.MinWorkers {
-		return fmt.Errorf("resources.max_workers must be >= resources.min_workers")
+	if c.Resources.MaxWorkers < c.Resources.TargetIdle {
+		return fmt.Errorf("resources.max_workers must be >= resources.target_idle")
 	}
 	if c.Resources.MemoryLimitMB < 1 {
 		return fmt.Errorf("resources.memory_limit_mb must be >= 1")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,14 +16,13 @@ worker:
   env:
     - FOO=bar
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 4
   memory_limit_mb: 512
   cpu_limit_cores: 1
   pids_limit: 100
   ttl: 10m
   health_interval: 5s
-  worker_reuse: true
 telemetry:
   log_format: json
   metrics_path: /metrics
@@ -58,14 +57,13 @@ network:
 worker:
   command: ["python3", "worker.py"]
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 4
   memory_limit_mb: 512
   cpu_limit_cores: 1
   pids_limit: 100
   ttl: 10m
   health_interval: 5s
-  worker_reuse: true
 `)
 
 	_, err := Load(path)

--- a/options.go
+++ b/options.go
@@ -21,7 +21,6 @@ package herd
 
 import "time"
 
-
 // ---------------------------------------------------------------------------
 // config — internal knobs for Pool
 // ---------------------------------------------------------------------------
@@ -166,5 +165,3 @@ func WithHealthInterval(d time.Duration) Option {
 func WithStartHealthCheckDelay(d time.Duration) Option {
 	return func(c *config) { c.startHealthCheckDelay = d }
 }
-
-

--- a/options.go
+++ b/options.go
@@ -30,9 +30,10 @@ import "time"
 // Defaults are set in defaultConfig(); all fields are safe to read concurrently
 // after New[C] returns because they are never mutated after that point.
 type config struct {
-	// min is the floor: the pool always keeps at least this many workers alive.
+	// targetIdle is the number of idle workers the pool attempts to keep ready
+	// at all times.
 	// Default: 1
-	min int
+	targetIdle int
 
 	// max is the ceiling: the pool will never spawn more than this many workers.
 	// Default: 10
@@ -56,11 +57,6 @@ type config struct {
 	crashHandler func(sessionID string)
 
 	startHealthCheckDelay time.Duration
-
-	// reuseWorkers controls if workers are recycled or killed when their
-	// session expires.
-	// Default: true
-	reuseWorkers bool
 }
 
 // defaultConfig returns the baseline configuration.
@@ -68,12 +64,11 @@ type config struct {
 // herd.New(factory) with no extra options produces a working pool.
 func defaultConfig() config {
 	return config{
-		min:                   1,
+		targetIdle:            1,
 		max:                   10,
 		ttl:                   5 * time.Minute,
 		healthInterval:        5 * time.Second,
 		startHealthCheckDelay: 1 * time.Second,
-		reuseWorkers:          true,
 	}
 }
 
@@ -88,23 +83,23 @@ type Option func(*config)
 // WithAutoScale — pool sizing
 // ---------------------------------------------------------------------------
 
-// WithAutoScale sets the minimum and maximum number of live workers.
+// WithAutoScale sets the target number of idle workers and the max capacity.
 //
-//   - min: the pool always keeps at least this many workers healthy,
-//     even with zero active sessions.
+//   - targetIdle: the pool proactively maintains this many unused workers on standby
+//     to absorb usage bursts.
 //   - max: hard cap on concurrent workers; Acquire blocks once this limit
 //     is reached until a worker becomes available.
 //
-// Panics if min < 1 or max < min.
-func WithAutoScale(min, max int) Option {
-	if min < 1 {
-		panic("herd: WithAutoScale min must be >= 1")
+// Panics if targetIdle < 1 or max < targetIdle.
+func WithAutoScale(targetIdle, max int) Option {
+	if targetIdle < 1 {
+		panic("herd: WithAutoScale targetIdle must be >= 1")
 	}
-	if max < min {
-		panic("herd: WithAutoScale max must be >= min")
+	if max < targetIdle {
+		panic("herd: WithAutoScale max must be >= targetIdle")
 	}
 	return func(c *config) {
-		c.min = min
+		c.targetIdle = targetIdle
 		c.max = max
 	}
 }
@@ -172,14 +167,4 @@ func WithStartHealthCheckDelay(d time.Duration) Option {
 	return func(c *config) { c.startHealthCheckDelay = d }
 }
 
-// ---------------------------------------------------------------------------
-// WithWorkerReuse — worker recycling policy
-// ---------------------------------------------------------------------------
 
-// WithWorkerReuse controls whether a worker is recycled when its session's TTL
-// expires. If true (the default), the worker is returned to the available pool
-// to serve new sessions. If false, the worker process is killed when the session
-// expires, and a fresh worker is spawned to maintain the minimum pool capacity.
-func WithWorkerReuse(reuse bool) Option {
-	return func(c *config) { c.reuseWorkers = reuse }
-}

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,13 @@
+with open("tests/e2e/test_production_burst.py", "r") as f:
+    code = f.read()
+
+old_burst = "burst_tasks = [asyncio.create_task(burst_worker(i)) for i in range(BURST_SESSIONS)]"
+new_burst = """burst_tasks = []
+    for i in range(BURST_SESSIONS):
+        burst_tasks.append(asyncio.create_task(burst_worker(i)))
+        await asyncio.sleep(0.01)"""
+        
+code = code.replace(old_burst, new_burst)
+
+with open("tests/e2e/test_production_burst.py", "w") as f:
+    f.write(code)

--- a/pool.go
+++ b/pool.go
@@ -171,18 +171,40 @@ func New[C any](factory WorkerFactory[C], opts ...Option) (*Pool[C], error) {
 		cancel:    cancel,
 	}
 
-	// Start the minimum number of workers synchronously.
-	// All min workers must be healthy before New returns.
-	for i := 0; i < cfg.min; i++ {
-		w, err := factory.Spawn(context.Background())
-		if err != nil {
-			// Best-effort cleanup of already-started workers
-			for _, started := range p.workers {
-				_ = started.Close()
-			}
-			return nil, fmt.Errorf("herd: New: failed to start initial worker %d: %w", i, err)
+	// Start the target number of idle workers concurrently.
+	// All initial workers must be healthy before New returns.
+	if cfg.targetIdle > 0 {
+		var wg sync.WaitGroup
+		errs := make(chan error, cfg.targetIdle)
+
+		for i := 0; i < cfg.targetIdle; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				w, err := factory.Spawn(context.Background())
+				if err != nil {
+					errs <- fmt.Errorf("herd: New: failed to start initial worker %d: %w", idx, err)
+					return
+				}
+				p.wireWorker(w)
+			}(i)
 		}
-		p.wireWorker(w)
+
+		wg.Wait()
+		close(errs)
+
+		if err, hasErr := <-errs; hasErr {
+			// Best-effort cleanup of already-started workers
+			p.mu.Lock()
+			started := make([]Worker[C], len(p.workers))
+			copy(started, p.workers)
+			p.mu.Unlock()
+
+			for _, w := range started {
+				_ = w.Close()
+			}
+			return nil, err
+		}
 	}
 
 	// Background loops
@@ -320,6 +342,10 @@ func (p *Pool[C]) Acquire(ctx context.Context, sessionID string) (*Session[C], e
 		close(ch) // broadcast: all goroutines blocked in SINGLEFLIGHT WAIT unblock
 
 		log.Printf("[pool] Acquire(%q): pinned to worker %s", sessionID, w.ID())
+		
+		// Proactively trigger backfill immediately after consuming a worker
+		p.maybeScaleUp()
+		
 		return &Session[C]{ID: sessionID, Worker: w, pool: p}, nil
 	}
 }
@@ -350,12 +376,13 @@ func (p *Pool[C]) GetSession(ctx context.Context, sessionID string) (*Session[C]
 // release — called by Session.Release
 // ---------------------------------------------------------------------------
 
-// release removes the session → worker binding and returns the worker to the
-// available channel. Internal; external callers use Session.Release().
+// release removes the session → worker binding, closes the worker,
+// and effectively disposes of it since we disabled worker reuse.
+// Internal; external callers use Session.Release().
 func (p *Pool[C]) release(sessionID string, w Worker[C]) {
 	p.mu.Lock()
 	_ = p.registry.Delete(context.Background(), sessionID)
-	// Validate the worker wasn't evicted by a crash or health check
+	// Validate the worker wasn't already evicted
 	isValid := false
 	for _, existing := range p.workers {
 		if existing.ID() == w.ID() {
@@ -366,19 +393,19 @@ func (p *Pool[C]) release(sessionID string, w Worker[C]) {
 	p.mu.Unlock()
 
 	if !isValid {
-		log.Printf("[pool] release(%q): worker %s already evicted (crash or health-check), discarding", sessionID, w.ID())
+		log.Printf("[pool] release(%q): worker %s already evicted, discarding", sessionID, w.ID())
 		return
 	}
 
-	log.Printf("[pool] release(%q): worker %s returned to pool", sessionID, w.ID())
-
-	// Non-blocking push: if the channel is somehow already full (shouldn't
-	// happen with 1-session-per-worker) log and drop rather than deadlock.
-	select {
-	case p.available <- w:
-	default:
-		log.Printf("[pool] release(%q): available channel full — this is a bug", sessionID)
+	// Always close single-use workers instead of putting them back
+	if err := w.Close(); err != nil {
+		log.Printf("[pool] release(%q): worker %s close error: %v", sessionID, w.ID(), err)
 	}
+
+	p.removeWorker(w)
+	p.maybeScaleUp()
+
+	log.Printf("[pool] release(%q): worker %s terminated per single-use policy", sessionID, w.ID())
 }
 
 // KillWorker forcefully tears down the worker pinned to sessionID.
@@ -448,24 +475,32 @@ func (p *Pool[C]) onCrash(sessionID string) {
 // Scale helpers
 // ---------------------------------------------------------------------------
 
-// maybeScaleUp fires addWorker in a goroutine if the pool is below its ceiling
-// and there are no free workers. Uses the workers slice length + a pendingAdds
+// maybeScaleUp proactively spawns new background workers to maintain a buffer
+// of targetIdle idle workers. It uses the workers slice length + a pendingAdds
 // counter to avoid overshooting max under concurrent scale-up pressure.
 func (p *Pool[C]) maybeScaleUp() {
 	p.mu.Lock()
-	// p.available should be read with lock to avoid race conditions
-	if len(p.available) > 0 {
-		p.mu.Unlock()
+	defer p.mu.Unlock()
+
+	deficit := p.cfg.targetIdle - (len(p.available) + p.pendingAdds)
+	if deficit <= 0 {
 		return
 	}
+
 	total := len(p.workers) + p.pendingAdds
-	if total < p.cfg.max {
-		p.pendingAdds++
-		p.mu.Unlock()
-		go p.addWorker()
+	headroom := p.cfg.max - total
+	if deficit > headroom {
+		deficit = headroom
+	}
+
+	if deficit <= 0 {
 		return
 	}
-	p.mu.Unlock()
+
+	p.pendingAdds += deficit
+	for i := 0; i < deficit; i++ {
+		go p.addWorker()
+	}
 }
 
 // addWorker spawns one new worker and registers it. Runs in its own goroutine.

--- a/pool.go
+++ b/pool.go
@@ -342,10 +342,10 @@ func (p *Pool[C]) Acquire(ctx context.Context, sessionID string) (*Session[C], e
 		close(ch) // broadcast: all goroutines blocked in SINGLEFLIGHT WAIT unblock
 
 		log.Printf("[pool] Acquire(%q): pinned to worker %s", sessionID, w.ID())
-		
+
 		// Proactively trigger backfill immediately after consuming a worker
 		p.maybeScaleUp()
-		
+
 		return &Session[C]{ID: sessionID, Worker: w, pool: p}, nil
 	}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -304,43 +304,79 @@ func TestCrashDuringAcquire(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 4 — Release: worker is returned to available pool after Session.Release
+// Test 4 — Release: worker is destroyed and backfilled after Session.Release
 // ---------------------------------------------------------------------------
 
-func TestReleaseReturnsWorkerToPool(t *testing.T) {
-	w := &stubWorker{id: "worker-1"}
-	pool := newTestPool(t, w)
+func TestReleaseDestroysWorkerAndBackfills(t *testing.T) {
+	w1 := &stubWorker{id: "worker-1"}
+	w2 := &stubWorker{id: "worker-2"}
+	
+	// Create factory explicitly so we can consume w1 manually, leaving w2 for the backfill
+	factory := newStubFactory(w1, w2)
+	
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	
+	cfg := defaultConfig()
+	cfg.targetIdle = 1 // one idle worker expected
+	cfg.max = 2
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	p := &Pool[*stubClient]{
+		factory:   factory,
+		cfg:       cfg,
+		registry:  NewLocalRegistry[*stubClient](),
+		inflight:  make(map[string]chan struct{}),
+		workers:   make([]Worker[*stubClient], 0, cfg.max),
+		available: make(chan Worker[*stubClient], cfg.max),
+		done:      make(chan struct{}),
+		ctx:       ctx,
+		cancel:    cancel,
+	}
 
-	sess, err := pool.Acquire(ctx, "session-z")
+	// Manually wire w1 into the pool and increment factory index so w2 is next
+	p.workers = append(p.workers, w1)
+	p.available <- w1
+	factory.index = 1 
+
+	cCtx, cCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cCancel()
+
+	sess, err := p.Acquire(cCtx, "session-z")
 	if err != nil {
 		t.Fatalf("Acquire: %v", err)
 	}
 
-	// After Acquire, pool should have 0 available workers
-	if got := pool.Stats().AvailableWorkers; got != 0 {
-		t.Fatalf("expected 0 available after Acquire, got %d", got)
-	}
 	// Verify session is pinned
-	if n := pool.registry.Len(); n != 1 {
+	if n := p.registry.Len(); n != 1 {
 		t.Fatalf("expected 1 session pinned, got %d", n)
 	}
-	sessions, _ := pool.registry.List(context.Background())
-	if worker, ok := sessions["session-z"]; !ok || worker != w {
+	sessions, _ := p.registry.List(context.Background())
+	if worker, ok := sessions["session-z"]; !ok || worker != w1 {
 		t.Fatalf("session-z should be pinned to worker w1")
+	}
+
+	// Wait briefly to allow Acquire's internal call to maybeScaleUp to finish spawning w2
+	time.Sleep(50 * time.Millisecond)
+
+	// Since we acquired w1, availability dropped to 0, causing a spawn of w2.
+	// So available should go back up to 1.
+	if got := p.Stats().AvailableWorkers; got != 1 {
+		t.Errorf("expected 1 available backfilled worker, got %d", got)
 	}
 
 	sess.Release()
 
-	// After Release, worker should be back
-	if got := pool.Stats().AvailableWorkers; got != 1 {
-		t.Errorf("expected 1 available after Release, got %d", got)
+	// Wait briefly to allow release's maybeScaleUp to process (though factory is empty now)
+	time.Sleep(50 * time.Millisecond)
+
+	// After Release, the worker should be closed. We no longer return the worker to the pool.
+	// Since w2 was already available, we have 1.
+	if got := p.Stats().AvailableWorkers; got != 1 {
+		t.Errorf("expected 1 available after Release backfill, got %d", got)
 	}
 
 	// And the session should be gone from the map
-	w_gone, _ := pool.registry.Get(context.Background(), "session-z")
+	w_gone, _ := p.registry.Get(context.Background(), "session-z")
 	if w_gone != nil {
 		t.Error("session-z should not exist in session map after Release")
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -310,13 +310,13 @@ func TestCrashDuringAcquire(t *testing.T) {
 func TestReleaseDestroysWorkerAndBackfills(t *testing.T) {
 	w1 := &stubWorker{id: "worker-1"}
 	w2 := &stubWorker{id: "worker-2"}
-	
+
 	// Create factory explicitly so we can consume w1 manually, leaving w2 for the backfill
 	factory := newStubFactory(w1, w2)
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	
+
 	cfg := defaultConfig()
 	cfg.targetIdle = 1 // one idle worker expected
 	cfg.max = 2
@@ -336,7 +336,7 @@ func TestReleaseDestroysWorkerAndBackfills(t *testing.T) {
 	// Manually wire w1 into the pool and increment factory index so w2 is next
 	p.workers = append(p.workers, w1)
 	p.available <- w1
-	factory.index = 1 
+	factory.index = 1
 
 	cCtx, cCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cCancel()

--- a/testdata/herd.yaml
+++ b/testdata/herd.yaml
@@ -6,8 +6,8 @@ worker:
   env:
     - FOO=bar
 resources:
-  min_workers: 1
-  max_workers: 4
+  target_idle: 25
+  max_workers: 100
   memory_limit_mb: 512
   cpu_limit_cores: 1
   pids_limit: 100

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -194,14 +194,14 @@ worker:
   command: ["{worker_bin}"]
   health_path: "/health"
 resources:
-  target_idle: 25
-  max_workers: 150
+  target_idle: 150
+  max_workers: 1000
   memory_limit_mb: 64
   cpu_limit_cores: 0.3
   pids_limit: 1024
   insecure_sandbox: true
   data_timeout: "60s"
-  heartbeat_grace: "10s"
+  heartbeat_grace: "30s"
 ''')
     
     print(f"\\n[+] Starting STRESS daemon at {sock_path} on data port {data_port}")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -71,7 +71,7 @@ worker:
   command: ["{worker_bin}"]
   health_path: "/health"
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 5
   memory_limit_mb: 512
   cpu_limit_cores: 1.0
@@ -135,7 +135,7 @@ worker:
   command: ["{worker_bin}"]
   health_path: "/health"
 resources:
-  min_workers: 1
+  target_idle: 1
   max_workers: 5
   memory_limit_mb: 512
   cpu_limit_cores: 1.0
@@ -194,13 +194,13 @@ worker:
   command: ["{worker_bin}"]
   health_path: "/health"
 resources:
-  min_workers: 5
+  target_idle: 25
   max_workers: 150
   memory_limit_mb: 64
   cpu_limit_cores: 0.3
   pids_limit: 1024
   insecure_sandbox: true
-  data_timeout: "10s"
+  data_timeout: "60s"
   heartbeat_grace: "10s"
 ''')
     

--- a/tests/e2e/test_production_burst.py
+++ b/tests/e2e/test_production_burst.py
@@ -1,0 +1,110 @@
+import asyncio
+import httpx
+import pytest
+import time
+import random
+from herd import AsyncClient
+
+@pytest.mark.asyncio
+async def test_production_burst(herd_daemon_stress):
+    """
+    Simulates a production environment where:
+    1. A baseline of active sessions is established and held open.
+    2. A massive unexpected "burst" of requests hits the system concurrently.
+    3. The pool must seamlessly provision and assign capacity (target_idle mechanics).
+    4. The burst traffic gracefully finishes and resources are successfully released (burst down).
+    5. The baseline traffic remains unaffected throughout the chaos.
+    """
+    
+    client = AsyncClient(address=herd_daemon_stress)
+    
+    BASELINE_SESSIONS = 50
+    BURST_SESSIONS = 60
+    
+    baseline_contexts = []
+    baseline_tasks = []
+    
+    async def baseline_worker(ctx, idx: int):
+        try:
+            session = await ctx.__aenter__()
+            # Keep baseline session busy to ensure it isn't affected
+            proxy_url = session.proxy_url
+            headers = {"X-Session-ID": session.id}
+            
+            async with httpx.AsyncClient() as hc:
+                # Do continuous health checks equivalent to long-running work
+                for _ in range(15):
+                    resp = await hc.get(f"{proxy_url}/health", headers=headers, timeout=5.0)
+                    resp.raise_for_status()
+                    await asyncio.sleep(0.5)
+                    
+            return True
+        except Exception as e:
+            print(f"[!] Baseline {idx} failed: {e}")
+            return False
+
+    print(f"\n[+] Establishing baseline traffic with {BASELINE_SESSIONS} concurrent sessions...")
+    # 1. Establish baseline
+    for i in range(BASELINE_SESSIONS):
+        ctx = client.acquire(worker_type="healthworker", timeout=15)
+        baseline_contexts.append(ctx)
+        baseline_tasks.append(asyncio.create_task(baseline_worker(ctx, i)))
+        
+    # Give the baseline a tiny bit of time to acquire
+    await asyncio.sleep(2.0)
+    
+    async def burst_worker(idx: int):
+        try:
+            # Add up to 20ms jitter to avoid perfect thundering herd event-loop lockup
+            await asyncio.sleep(random.uniform(0, 0.020))
+            
+            start_time = time.time()
+            ctx = client.acquire(worker_type="healthworker", timeout=20)
+            session = await ctx.__aenter__()
+            acquire_time = time.time() - start_time
+            
+            # Simulate processing of burst traffic
+            proxy_url = session.proxy_url
+            headers = {"X-Session-ID": session.id}
+            
+            async with httpx.AsyncClient() as hc:
+                resp = await hc.get(f"{proxy_url}/health", headers=headers, timeout=5.0)
+                resp.raise_for_status()
+                # Do a little arbitrary work
+                await asyncio.sleep(5)
+                
+            await ctx.__aexit__(None, None, None)
+            return True, acquire_time
+        except Exception as e:
+            print(f"[!] Burst {idx} failed: {e}")
+            return False, 0.0
+
+    print(f"\n[+] Incoming burst traffic: {BURST_SESSIONS} concurrent sessions...")
+    
+    # 2. Trigger Burst Up
+    burst_start = time.time()
+    burst_tasks = [asyncio.create_task(burst_worker(i)) for i in range(BURST_SESSIONS)]
+    burst_results = await asyncio.gather(*burst_tasks)
+    burst_total_time = time.time() - burst_start
+    successes = sum(1 for success, _ in burst_results if success)
+    max_acquire = max(latency for success, latency in burst_results if success)
+    
+    print(f"\n[+] Burst Traffic Complete.")
+    print(f"    - Success: {successes} / {BURST_SESSIONS}")
+    print(f"    - Max Acquisition Latency: {max_acquire:.2f}s")
+    print(f"    - Total Burst Duration: {burst_total_time:.2f}s")
+    
+    assert successes == BURST_SESSIONS, f"Dropped traffic during burst! {BURST_SESSIONS - successes} failed."
+    assert max_acquire < 15.0, "Worker provisioning took too long during burst scale up."
+    
+    # 3. Burst traffic is done. Wait for baseline to finish its run.
+    print(f"\n[+] Burst traffic complete. Awaiting baseline task completion...")
+    baseline_results = await asyncio.gather(*baseline_tasks)
+    baseline_successes = sum(1 for success in baseline_results if success)
+
+    print(f"\n[+] Cleaning up baseline traffic...")
+    for ctx in baseline_contexts:
+        await ctx.__aexit__(None, None, None)
+    
+    assert baseline_successes == BASELINE_SESSIONS, "Baseline traffic failed while defending against burst!"
+    print("[+] Production burst scaling handled smoothly.")


### PR DESCRIPTION
- Replacing minWorkers with idleTarget to always have idleTarget workers available in pool for prewarming.
- Added a new test for testing burst concurrent sessions to simulate load similar to real production load.