### PR TITLE
fixing idle timeout from cmdline

### DIFF
--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -17,6 +17,7 @@ import (
 var (
 	deployImage   string
 	deployTimeout int
+	absoluteDeployTimeout int
 	deployCommand []string
 	deployEnv     []string
 )
@@ -34,6 +35,7 @@ var deployCmd = &cobra.Command{
 		req := map[string]any{
 			"image":                deployImage,
 			"idle_timeout_seconds": deployTimeout,
+			"ttl_seconds": absoluteDeployTimeout,
 		}
 		if len(deployCommand) > 0 {
 			req["command"] = deployCommand
@@ -83,5 +85,6 @@ func init() {
 	deployCmd.Flags().StringVar(&deployImage, "image", "docker.io/library/alpine:latest", "Image to deploy")
 	deployCmd.Flags().StringSliceVar(&deployCommand, "cmd", nil, "Command to run inside the VM (e.g. --cmd=/bin/sh,-c,\"echo hello\")")
 	deployCmd.Flags().StringArrayVarP(&deployEnv, "env", "e", nil, "Set environment variables (e.g. -e POSTGRES_PASSWORD=secret)")
-	deployCmd.Flags().IntVar(&deployTimeout, "timeout", 300, "Idle timeout in seconds")
+	deployCmd.Flags().IntVar(&deployTimeout, "timeout", 0, "Idle timeout in seconds")
+	deployCmd.Flags().IntVar(&absoluteDeployTimeout, "absolute-timeout", 0, "Absolute timeout in seconds")
 }


### PR DESCRIPTION
This pull request introduces support for specifying an absolute timeout when deploying with the `herd` CLI tool. In addition to the existing idle timeout, users can now set a maximum lifetime (absolute timeout) for deployments. The changes update the CLI flags and ensure the new value is included in the deployment request.

New deployment timeout support:

* Added an `absoluteDeployTimeout` variable and a corresponding `--absolute-timeout` CLI flag to specify an absolute timeout in seconds for deployments in `cmd/herd/deploy.go`. [[1]](diffhunk://#diff-f05debcfd01afb88c2908d90b82cf7c8d3bb8f7b157cd2b91d8c4632574589dfR20) [[2]](diffhunk://#diff-f05debcfd01afb88c2908d90b82cf7c8d3bb8f7b157cd2b91d8c4632574589dfL86-R89)
* Updated the deployment request to include the `ttl_seconds` field, passing the absolute timeout value to the backend in `cmd/herd/deploy.go`.

Other adjustments:

* Changed the default value for the existing `--timeout` (idle timeout) flag from 300 seconds to 0, making it explicit that no idle timeout is set unless specified.