### PR TITLE
initial jailer implementation

### DIFF
--- a/cmd/herd/exec.go
+++ b/cmd/herd/exec.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/herd-core/herd/internal/config"
 	"github.com/herd-core/herd/internal/vsock"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -32,8 +33,14 @@ func init() {
 }
 
 func runExec(vmID string) error {
-	// The factory creates sockets in /tmp/<vm-id>.sock
-	socketPath := filepath.Join("/tmp", fmt.Sprintf("%s.sock", vmID))
+	// Load config to find the jailer chroot base directory
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config %q: %w", configPath, err)
+	}
+
+	// The factory creates sockets in <JailerChrootBaseDir>/firecracker/<vmID>/root/run/<vmID>.sock
+	socketPath := filepath.Join(cfg.Jailer.ChrootBaseDir, "firecracker", vmID, "root", "run", fmt.Sprintf("%s.sock", vmID))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -9,8 +9,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/herd-core/herd/internal/config"
@@ -20,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
+
 
 
 var initCmd = &cobra.Command{
@@ -62,17 +65,20 @@ func runInit() {
 	}
 
 	// 2. Binaries
-	var fcPath string
-	useExistingFC := promptConfirm(reader, "Do you already have Firecracker installed? (y/n)", false)
+	var fcPath, jailerPath string
+	useExistingFC := promptConfirm(reader, "Do you already have Firecracker and jailer installed? (y/n)", false)
 	if useExistingFC {
 		fcPath = promptString(reader, "Path to firecracker binary (default: /usr/local/bin/firecracker)", "/usr/local/bin/firecracker")
+		jailerPath = promptString(reader, "Path to jailer binary (default: /usr/local/bin/jailer)", "/usr/local/bin/jailer")
 	} else {
 		fcPath = filepath.Join(binDir, "firecracker")
-		fmt.Println("Downloading Firecracker v1.14.3...")
-		if err := downloadFirecracker(fcPath); err != nil {
-			log.Fatalf("failed to download firecracker: %v", err)
+		jailerPath = filepath.Join(binDir, "jailer")
+		fmt.Println("Downloading Firecracker v1.14.3 (includes jailer)...")
+		if err := downloadFirecrackerAndJailer(fcPath, jailerPath); err != nil {
+			log.Fatalf("failed to download firecracker/jailer: %v", err)
 		}
 		fmt.Printf("✅ Firecracker installed: %s\n", fcPath)
+		fmt.Printf("✅ Jailer installed: %s\n", jailerPath)
 	}
 
 	// Guest Agent - Download pre-compiled binary
@@ -95,6 +101,24 @@ func runInit() {
 			log.Fatalf("failed to download kernel: %v", err)
 		}
 	}
+	fmt.Println()
+
+	// 4. Jailer user+group and chroot base dir
+	fmt.Println("--- Jailer Configuration ---")
+	chrootBaseDir := promptString(reader, "Jailer chroot base dir (default: /srv/jailer)", "/srv/jailer")
+	const jailerUID, jailerGID = 900, 900
+	fmt.Printf("Provisioning 'firecracker' user (uid=%d, gid=%d)...\n", jailerUID, jailerGID)
+	if err := provisionJailerUser(jailerUID, jailerGID); err != nil {
+		log.Fatalf("failed to provision jailer user: %v", err)
+	}
+	fmt.Println("✅ 'firecracker' user/group ready")
+	if err := os.MkdirAll(chrootBaseDir, 0755); err != nil {
+		log.Fatalf("failed to create chroot base dir: %v", err)
+	}
+	if err := os.Chown(chrootBaseDir, jailerUID, jailerGID); err != nil {
+		log.Fatalf("failed to chown chroot base dir: %v", err)
+	}
+	fmt.Printf("✅ Chroot base dir ready: %s\n", chrootBaseDir)
 	fmt.Println()
 
 	// 4. Resource Limits
@@ -134,8 +158,14 @@ func runInit() {
 		},
 		Binaries: config.BinaryConfig{
 			FirecrackerPath: fcPath,
+			JailerPath:      jailerPath,
 			KernelImagePath: kernelPath,
 			GuestAgentPath:  agentPath,
+		},
+		Jailer: config.JailerConfig{
+			UID:           jailerUID,
+			GID:           jailerGID,
+			ChrootBaseDir: chrootBaseDir,
 		},
 		Telemetry: config.TelemetryConfig{
 			LogFormat:   "json",
@@ -166,7 +196,9 @@ func runInit() {
 	fmt.Println("You can now start the daemon with: sudo herd start")
 }
 
-func downloadFirecracker(outputPath string) error {
+// downloadFirecrackerAndJailer downloads the Firecracker release tarball and
+// extracts both the firecracker and jailer binaries in a single HTTP round-trip.
+func downloadFirecrackerAndJailer(fcOutputPath, jailerOutputPath string) error {
 	arch := runtime.GOARCH
 	if arch == "amd64" {
 		arch = "x86_64"
@@ -184,16 +216,16 @@ func downloadFirecracker(outputPath string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download firecracker: %s", resp.Status)
+		return fmt.Errorf("failed to download firecracker release: %s", resp.Status)
 	}
 
-	// Extract .tgz
 	gzr, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		return err
 	}
 	defer gzr.Close()
 
+	fcDone, jailerDone := false, false
 	tr := tar.NewReader(gzr)
 	for {
 		header, err := tr.Next()
@@ -204,22 +236,80 @@ func downloadFirecracker(outputPath string) error {
 			return err
 		}
 
-		// The binary in the tar is usually named "firecracker-v1.14.3-x86_64"
-		if strings.Contains(header.Name, "firecracker-v") && !strings.Contains(header.Name, ".debug") {
-			out, err := os.Create(outputPath)
-			if err != nil {
-				return err
+		switch {
+		case strings.Contains(header.Name, "firecracker-v") && !strings.Contains(header.Name, ".debug") && !strings.Contains(header.Name, "jailer"):
+			if err := extractBinaryFromTar(tr, fcOutputPath); err != nil {
+				return fmt.Errorf("extract firecracker: %w", err)
 			}
-			defer out.Close()
+			fcDone = true
+		case strings.Contains(header.Name, "jailer-v") && !strings.Contains(header.Name, ".debug"):
+			if err := extractBinaryFromTar(tr, jailerOutputPath); err != nil {
+				return fmt.Errorf("extract jailer: %w", err)
+			}
+			jailerDone = true
+		}
 
-			if _, err := io.Copy(out, tr); err != nil {
-				return err
-			}
-			return os.Chmod(outputPath, 0755)
+		if fcDone && jailerDone {
+			break
 		}
 	}
 
-	return fmt.Errorf("firecracker binary not found in archive")
+	if !fcDone {
+		return fmt.Errorf("firecracker binary not found in archive")
+	}
+	if !jailerDone {
+		return fmt.Errorf("jailer binary not found in archive")
+	}
+	return nil
+}
+
+func extractBinaryFromTar(r io.Reader, outputPath string) error {
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, r); err != nil {
+		return err
+	}
+	return os.Chmod(outputPath, 0755)
+}
+
+// provisionJailerUser ensures the 'firecracker' group and user exist with the
+// given uid/gid. It is idempotent — if they already exist the calls are skipped.
+func provisionJailerUser(uid, gid int) error {
+	uidStr := strconv.Itoa(uid)
+	gidStr := strconv.Itoa(gid)
+
+	// Create group if it doesn't exist.
+	groupCheckCmd := exec.Command("getent", "group", "firecracker")
+	if err := groupCheckCmd.Run(); err != nil {
+		// Group does not exist — create it.
+		out, err := exec.Command("groupadd", "--gid", gidStr, "firecracker").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("groupadd firecracker: %s (%w)", strings.TrimSpace(string(out)), err)
+		}
+	}
+
+	// Create user if it doesn't exist.
+	userCheckCmd := exec.Command("getent", "passwd", "firecracker")
+	if err := userCheckCmd.Run(); err != nil {
+		// User does not exist — create it as a system user with no login shell.
+		out, err := exec.Command(
+			"useradd",
+			"--uid", uidStr,
+			"--gid", gidStr,
+			"--no-create-home",
+			"--shell", "/sbin/nologin",
+			"--system",
+			"firecracker",
+		).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("useradd firecracker: %s (%w)", strings.TrimSpace(string(out)), err)
+		}
+	}
+
+	return nil
 }
 
 func downloadGuestAgent(path string) error {

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -187,12 +187,15 @@ func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {
 	}
 
 	factory := &herd.FirecrackerFactory{
-		FirecrackerPath: cfg.Binaries.FirecrackerPath,
-		KernelImagePath: cfg.Binaries.KernelImagePath,
-		Storage:         mgr,
-		SocketPathDir:   "/tmp",
-		GuestAgentPath:  cfg.Binaries.GuestAgentPath,
-		IPAM:            ipam,
+		FirecrackerPath:     cfg.Binaries.FirecrackerPath,
+		JailerPath:          cfg.Binaries.JailerPath,
+		KernelImagePath:     cfg.Binaries.KernelImagePath,
+		GuestAgentPath:      cfg.Binaries.GuestAgentPath,
+		Storage:             mgr,
+		IPAM:                ipam,
+		JailerUID:           cfg.Jailer.UID,
+		JailerGID:           cfg.Jailer.GID,
+		JailerChrootBaseDir: cfg.Jailer.ChrootBaseDir,
 	}
 
 	return herd.New(factory,

--- a/cmd/test_boot/main.go
+++ b/cmd/test_boot/main.go
@@ -38,12 +38,15 @@ func main() {
 	}
 
 	factory := &herd.FirecrackerFactory{
-		FirecrackerPath: "/home/hackstrix/firecracker-v15.0/firecracker",
-		KernelImagePath: filepath.Join(cwd, "assets/vmlinux.bin"),
-		Storage:         mgr,
-		SocketPathDir:   "/tmp",
-		GuestAgentPath:  filepath.Join(cwd, "herd-guest-agent"),
-		IPAM:            ipam,
+		FirecrackerPath:     "/home/hackstrix/firecracker-v15.0/firecracker",
+		JailerPath:          "/home/hackstrix/firecracker-v15.0/jailer",
+		KernelImagePath:     filepath.Join(cwd, "assets/vmlinux.bin"),
+		Storage:             mgr,
+		GuestAgentPath:      filepath.Join(cwd, "herd-guest-agent"),
+		IPAM:                ipam,
+		JailerUID:           900,
+		JailerGID:           900,
+		JailerChrootBaseDir: "/srv/jailer",
 	}
 
 	for i := 0; i < 3; i++ {

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/herd-core/herd/internal/network"
@@ -18,17 +20,38 @@ import (
 	"github.com/herd-core/herd/internal/vsock"
 )
 
-// FirecrackerFactory is a minimal implementation of a WorkerFactory that spawns Firecracker VMs.
+// FirecrackerFactory is a WorkerFactory that spawns Firecracker VMs via the
+// jailer binary for secure, unprivileged isolation.
 type FirecrackerFactory struct {
+	// FirecrackerPath is the absolute host path to the firecracker binary.
+	// The jailer exec's it inside the chroot; it never runs as root.
 	FirecrackerPath string
+	// JailerPath is the absolute host path to the jailer binary.
+	JailerPath string
+	// KernelImagePath is the shared host path to the guest kernel image.
+	// It is hard-linked into each VM's chroot at /run/vmlinux before boot.
 	KernelImagePath string
-	// GuestAgentPath is the host path to the static herd-guest-agent binary; it is
-	// copied into each VM rootfs before boot (no initrd).
+	// GuestAgentPath is the host path to the static herd-guest-agent binary.
 	GuestAgentPath string
-	Storage        *storage.Manager
 
-	SocketPathDir string
-	IPAM          *network.IPAM
+	Storage *storage.Manager
+	IPAM    *network.IPAM
+
+	// JailerUID / JailerGID are the unprivileged uid/gid the jailer drops to
+	// after setting up cgroups and the chroot (typically the "firecracker" user).
+	JailerUID int
+	JailerGID int
+	// JailerChrootBaseDir is the root under which the jailer creates per-VM
+	// chroot directories: <JailerChrootBaseDir>/firecracker/<vmID>/root/
+	JailerChrootBaseDir string
+}
+
+// chrootRoot returns the chroot root directory for a given VM.
+// This matches the path the jailer creates:
+//
+//	<JailerChrootBaseDir>/firecracker/<vmID>/root
+func (f *FirecrackerFactory) chrootRoot(vmID string) string {
+	return filepath.Join(f.JailerChrootBaseDir, "firecracker", vmID, "root")
 }
 
 // FirecrackerWorker represents a single running Firecracker VM.
@@ -41,6 +64,7 @@ type FirecrackerWorker struct {
 	cmd        *exec.Cmd
 	client     *http.Client
 	ipam       *network.IPAM
+	chrootDir  string        // full chroot root path; removed on Close()
 	done       chan struct{} // closed when cmd.Wait() returns
 }
 
@@ -54,13 +78,12 @@ func (f *FirecrackerWorker) GuestIP() string {
 	return f.guestIP
 }
 
-// Address returns the HTTP base URL for the workload on the guest LAN (data-plane
-// reverse proxy). Exec and other vsock paths use VsockUDSPath.
+// Address returns the HTTP base URL for the workload on the guest LAN.
 func (f *FirecrackerWorker) Address() string {
 	return fmt.Sprintf("http://%s:80", f.guestIP)
 }
 
-// VsockUDSPath is the host Unix socket Firecracker exposes for vsock connect.
+// VsockUDSPath is the host-visible Unix socket Firecracker exposes for vsock.
 func (f *FirecrackerWorker) VsockUDSPath() string {
 	return f.socketPath
 }
@@ -70,15 +93,11 @@ func (f *FirecrackerWorker) Client() *http.Client {
 	return f.client
 }
 
-// Healthy checks if the VM is up. For now we just check if process is alive.
+// Healthy checks if the VM is up by verifying the process hasn't exited.
 func (f *FirecrackerWorker) Healthy(ctx context.Context) error {
-	// 1. Check if the Firecracker process has crashed (requires cmd.Wait() to be called in a goroutine)
 	if f.cmd.ProcessState != nil && f.cmd.ProcessState.Exited() {
 		return fmt.Errorf("firecracker process exited with code: %v", f.cmd.ProcessState.ExitCode())
 	}
-
-	// The HTTP ping check is temporarily disabled because the guest agent currently only speaks
-	// raw JSON payload format on port 5000 and has no HTTP proxy multiplexer over vsock.
 	return nil
 }
 
@@ -87,9 +106,9 @@ func (f *FirecrackerWorker) OnCrash(fn func(sessionID string)) {
 	// Not implemented for this minimal version
 }
 
-// Close kills the VM and cleans up resources. It blocks until the Firecracker
-// process has fully exited before tearing down storage, preventing "device busy"
-// errors on the devmapper thin volume.
+// Close kills the VM and cleans up all resources. It blocks until the
+// Firecracker process has fully exited before tearing down storage and the
+// chroot, preventing "device busy" errors.
 func (f *FirecrackerWorker) Close() error {
 	if f.cmd != nil && f.cmd.Process != nil {
 		_ = f.cmd.Process.Kill()
@@ -100,8 +119,12 @@ func (f *FirecrackerWorker) Close() error {
 		}
 	}
 
-	if err := os.Remove(f.socketPath); err != nil {
-		slog.Warn("failed to remove firecracker socket", "path", f.socketPath, "error", err)
+	// Remove the entire chroot jail directory tree (includes the vsock socket,
+	// the config JSON, the kernel hard-link, and the rootfs device node).
+	if f.chrootDir != "" {
+		if err := os.RemoveAll(f.chrootDir); err != nil {
+			slog.Warn("failed to remove jailer chroot directory", "path", f.chrootDir, "error", err)
+		}
 	}
 
 	_ = network.DeleteTap(f.tapName)
@@ -122,14 +145,12 @@ func (f *FirecrackerFactory) WarmImage(ctx context.Context, imageRef string) err
 	return f.Storage.WarmImage(ctx, imageRef)
 }
 
-// Spawn starts a new Firecracker VM.
+// Spawn starts a new Firecracker VM under the jailer.
 func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config TenantConfig) (Worker[*http.Client], error) {
 	spawnStart := time.Now()
-	workerID := sessionID // Use sessionID universally
-	socketPath := filepath.Join(f.SocketPathDir, fmt.Sprintf("%s.sock", workerID))
+	workerID := sessionID
 
 	t0 := time.Now()
-	// Ensure the image is warmed (pulled) before we try to extract config or snapshot
 	if err := f.Storage.WarmImage(ctx, config.Image); err != nil {
 		return nil, fmt.Errorf("failed to warm image: %w", err)
 	}
@@ -167,14 +188,56 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	}
 	log.Printf("[spawn:%s] inject guest     %v", workerID, time.Since(tInject))
 
-	// Ensure old socket is removed
-	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
-		slog.Warn("failed to remove legacy socket", "path", socketPath, "error", err)
+	// -------------------------------------------------------------------------
+	// Build the per-VM chroot.
+	// The jailer will later chroot into this directory; all paths inside the
+	// config JSON are relative to this root.
+	// -------------------------------------------------------------------------
+	chrootRoot := f.chrootRoot(workerID)
+	chrootRunDir := filepath.Join(chrootRoot, "run")
+	chrootDevDir := filepath.Join(chrootRoot, "dev")
+
+	if err := os.MkdirAll(chrootRunDir, 0700); err != nil {
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("create chroot run dir: %w", err)
+	}
+	if err := os.MkdirAll(chrootDevDir, 0755); err != nil {
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("create chroot dev dir: %w", err)
 	}
 
+	// Hard-link the shared kernel image into the chroot so Firecracker can
+	// open it without any host path access. Hard-linking is instant (same inode)
+	// and avoids copying the ~22 MB file on every spawn.
+	kernelInChroot := filepath.Join(chrootRunDir, "vmlinux")
+	if err := os.Link(f.KernelImagePath, kernelInChroot); err != nil {
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("hard-link kernel into chroot: %w", err)
+	}
+
+	// Create a block device node inside the chroot that mirrors the devmapper
+	// thin-volume returned by Snapshot. Firecracker will open /dev/vda inside
+	// the jail; this node has the same major/minor as the host /dev/dm-X device.
+	rootfsInChroot := filepath.Join(chrootDevDir, "vda")
+	if err := bindDeviceIntoChroot(rootfsPath, rootfsInChroot); err != nil {
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("bind rootfs device into chroot: %w", err)
+	}
+
+	// The vsock UDS socket lands inside the chroot; this is its host-visible path.
+	socketPath := filepath.Join(chrootRunDir, fmt.Sprintf("%s.sock", workerID))
+
+	// -------------------------------------------------------------------------
+	// IPAM + TAP
+	// -------------------------------------------------------------------------
 	t1 := time.Now()
 	guestIP, err := f.IPAM.Acquire()
 	if err != nil {
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("failed to acquire IP: %w", err)
 	}
 	log.Printf("[spawn:%s] IPAM.Acquire     %v", workerID, time.Since(t1))
@@ -190,24 +253,29 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	_ = network.DeleteTap(tapName)
 	if err := network.CreatePointToPointTap(tapName, hostIP, guestIP); err != nil {
 		f.IPAM.Release(guestIP)
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("failed to create tap device: %w", err)
 	}
 	log.Printf("[spawn:%s] TAP setup        %v", workerID, time.Since(t2))
 
 	macByte := fmt.Sprintf("%02x", time.Now().UnixNano()%256)
 
-	// Create a minimal config json
-	configPath := filepath.Join(f.SocketPathDir, fmt.Sprintf("%s.json", workerID))
+	// -------------------------------------------------------------------------
+	// Write Firecracker config JSON into the chroot.
+	// All paths here are absolute paths as seen from INSIDE the chroot jail.
+	// -------------------------------------------------------------------------
+	configPath := filepath.Join(chrootRunDir, fmt.Sprintf("%s.json", workerID))
 	initPath := storage.DefaultGuestAgentPath
 	configData := fmt.Sprintf(`{
 		"boot-source": {
-			"kernel_image_path": "%s",
+			"kernel_image_path": "/run/vmlinux",
 			"boot_args": "console=ttyS0 reboot=k panic=1 pci=off quiet mitigations=off i8042.nokbd i8042.noaux tsc=reliable random.trust_cpu=on random.trust_bootloader=on root=/dev/vda rw rootfstype=ext4 rootflags=noload,noinit_itable init=%s herd_rootfs=1 herd_ip=%s herd_gw=%s"
 		},
 		"drives": [
 			{
 				"drive_id": "rootfs",
-				"path_on_host": "%s",
+				"path_on_host": "/dev/vda",
 				"is_root_device": true,
 				"is_read_only": false
 			}
@@ -225,25 +293,50 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		},
 		"vsock": {
 			"guest_cid": 3,
-			"uds_path": "%s"
+			"uds_path": "/run/%s.sock"
 		},
 		"entropy": {}
-	}`, f.KernelImagePath, initPath, guestIP, hostIP, rootfsPath, macByte, tapName, socketPath)
+	}`, initPath, guestIP, hostIP, macByte, tapName, workerID)
 
 	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+		network.DeleteTap(tapName)
+		f.IPAM.Release(guestIP)
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("failed to write config: %w", err)
 	}
 
-	// The Firecracker process must outlive the HTTP request that spawned it, so use
-	// context.Background() instead of the request-scoped ctx. The request ctx is still
-	// used above for the spawn-time operations (image pull, snapshot, vsock wait).
-	cmd := exec.Command(f.FirecrackerPath, "--no-api", "--config-file", configPath)
+	// -------------------------------------------------------------------------
+	// Launch via jailer.
+	// The jailer:
+	//   1. Creates cgroups for the VM.
+	//   2. Chroots into chrootRoot (which it computes the same way we do).
+	//   3. Drops to JailerUID/JailerGID.
+	//   4. Exec's firecracker with the remaining args.
+	// The config-file path is relative to the chroot root, so we pass the
+	// in-chroot absolute path: /run/<vmID>.json
+	// -------------------------------------------------------------------------
+	cmd := exec.Command(
+		f.JailerPath,
+		"--id", workerID,
+		"--exec-file", f.FirecrackerPath,
+		"--uid", strconv.Itoa(f.JailerUID),
+		"--gid", strconv.Itoa(f.JailerGID),
+		"--chroot-base-dir", f.JailerChrootBaseDir,
+		"--",
+		"--no-api",
+		"--config-file", fmt.Sprintf("/run/%s.json", workerID),
+	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	t3 := time.Now()
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to start firecracker: %w", err)
+		_ = network.DeleteTap(tapName)
+		f.IPAM.Release(guestIP)
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("failed to start jailer: %w", err)
 	}
 	log.Printf("[spawn:%s] cmd.Start        %v", workerID, time.Since(t3))
 
@@ -253,9 +346,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		close(done)
 	}()
 
-	// Loop to wait for the VM to boot and accept vsock connections.
-	// 30s accommodates concurrent boot contention when multiple VMs
-	// share host CPU during pool initialization.
+	// Wait for the VM to boot and accept vsock connections.
 	t4 := time.Now()
 	deadline := time.Now().Add(30 * time.Second)
 	var execConn net.Conn
@@ -272,10 +363,16 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	log.Printf("[spawn:%s] vsock connect    %v", workerID, time.Since(t4))
 
 	if execConn == nil {
+		_ = cmd.Process.Kill()
+		<-done
+		_ = network.DeleteTap(tapName)
+		f.IPAM.Release(guestIP)
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("failed to connect to guest agent vsock port 5000 within timeout: %v", lastErr)
 	}
 
-	logPath := filepath.Join(f.SocketPathDir, fmt.Sprintf("%s.log", workerID))
+	logPath := filepath.Join(chrootRoot, fmt.Sprintf("%s.log", workerID))
 	logFile, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 
 	finalEnv := imgConfig.Env
@@ -283,7 +380,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		finalEnv = append(finalEnv, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Stream the workload payload down the vsock pipe
+	// Stream the workload payload down the vsock pipe.
 	go func() {
 		defer func() {
 			if cerr := logFile.Close(); cerr != nil {
@@ -299,11 +396,10 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		}
 	}()
 
-	// Create a custom HTTP Client that dials over vsock for HTTP routing
+	// Create a custom HTTP client that dials over vsock for HTTP routing.
 	agentClient := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// We ignore the actual address and force route to Guest CID 3 over the Firecracker UDS
 				return vsock.DialFirecracker(ctx, socketPath, 5000)
 			},
 		},
@@ -320,6 +416,30 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		client:     agentClient,
 		storage:    f.Storage,
 		ipam:       f.IPAM,
+		chrootDir:  chrootRoot,
 		done:       done,
 	}, nil
+}
+
+// bindDeviceIntoChroot creates a block device node at dstPath that mirrors
+// the major/minor numbers of the host device at srcPath.
+//
+// This is how Firecracker (running inside the chroot as an unprivileged user)
+// can open the devmapper thin-volume that containerd provisioned on the host:
+// the node has the same device numbers, so the kernel routes I/O to the same
+// underlying block layer.
+//
+// Requires CAP_MKNOD (satisfied by the daemon running as root).
+func bindDeviceIntoChroot(srcPath, dstPath string) error {
+	var stat syscall.Stat_t
+	if err := syscall.Stat(srcPath, &stat); err != nil {
+		return fmt.Errorf("stat source device %s: %w", srcPath, err)
+	}
+	// S_IFBLK | 0600 — block device, readable/writable only by root.
+	// Firecracker will be running as JailerUID but the kernel grants access
+	// via the jailer's cgroup device allowlist.
+	if err := syscall.Mknod(dstPath, syscall.S_IFBLK|0600, int(stat.Rdev)); err != nil {
+		return fmt.Errorf("mknod block device at %s: %w", dstPath, err)
+	}
+	return nil
 }

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -197,11 +197,32 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	chrootRunDir := filepath.Join(chrootRoot, "run")
 	chrootDevDir := filepath.Join(chrootRoot, "dev")
 
-	if err := os.MkdirAll(chrootRunDir, 0700); err != nil {
+	// Ensure the parent directory <base>/firecracker/<id> exists.
+	if err := os.MkdirAll(filepath.Dir(chrootRoot), 0755); err != nil {
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("create jail base dir: %w", err)
+	}
+
+	// Create the chroot root with 0700.
+	if err := os.Mkdir(chrootRoot, 0700); err != nil && !os.IsExist(err) {
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("create chroot root: %w", err)
+	}
+
+	// Chown the root to the jailer user/group so it can traverse into it.
+	if err := os.Chown(chrootRoot, f.JailerUID, f.JailerGID); err != nil {
+		_ = os.RemoveAll(chrootRoot)
+		_ = f.Storage.Teardown(ctx, workerID)
+		return nil, fmt.Errorf("chown chroot root: %w", err)
+	}
+
+	// Create run/dev dirs with 0700; they will be inside the already-protected root.
+	if err := os.Mkdir(chrootRunDir, 0700); err != nil && !os.IsExist(err) {
+		_ = os.RemoveAll(chrootRoot)
 		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("create chroot run dir: %w", err)
 	}
-	if err := os.MkdirAll(chrootDevDir, 0755); err != nil {
+	if err := os.Mkdir(chrootDevDir, 0700); err != nil && !os.IsExist(err) {
 		_ = os.RemoveAll(chrootRoot)
 		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("create chroot dev dir: %w", err)
@@ -221,7 +242,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	// thin-volume returned by Snapshot. Firecracker will open /dev/vda inside
 	// the jail; this node has the same major/minor as the host /dev/dm-X device.
 	rootfsInChroot := filepath.Join(chrootDevDir, "vda")
-	if err := bindDeviceIntoChroot(rootfsPath, rootfsInChroot); err != nil {
+	if err := bindDeviceIntoChroot(rootfsPath, rootfsInChroot, f.JailerUID, f.JailerGID); err != nil {
 		_ = os.RemoveAll(chrootRoot)
 		_ = f.Storage.Teardown(ctx, workerID)
 		return nil, fmt.Errorf("bind rootfs device into chroot: %w", err)
@@ -251,7 +272,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	}
 	tapName := "tap-" + workerID[len(workerID)-tapNameLen:]
 	_ = network.DeleteTap(tapName)
-	if err := network.CreatePointToPointTap(tapName, hostIP, guestIP); err != nil {
+	if err := network.CreatePointToPointTap(tapName, hostIP, guestIP, f.JailerUID, f.JailerGID); err != nil {
 		f.IPAM.Release(guestIP)
 		_ = os.RemoveAll(chrootRoot)
 		_ = f.Storage.Teardown(ctx, workerID)
@@ -430,7 +451,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 // underlying block layer.
 //
 // Requires CAP_MKNOD (satisfied by the daemon running as root).
-func bindDeviceIntoChroot(srcPath, dstPath string) error {
+func bindDeviceIntoChroot(srcPath, dstPath string, uid, gid int) error {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(srcPath, &stat); err != nil {
 		return fmt.Errorf("stat source device %s: %w", srcPath, err)
@@ -440,6 +461,10 @@ func bindDeviceIntoChroot(srcPath, dstPath string) error {
 	// via the jailer's cgroup device allowlist.
 	if err := syscall.Mknod(dstPath, syscall.S_IFBLK|0600, int(stat.Rdev)); err != nil {
 		return fmt.Errorf("mknod block device at %s: %w", dstPath, err)
+	}
+
+	if err := os.Chown(dstPath, uid, gid); err != nil {
+		return fmt.Errorf("chown block device at %s: %w", dstPath, err)
 	}
 	return nil
 }

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -64,8 +64,10 @@ type FirecrackerWorker struct {
 	cmd        *exec.Cmd
 	client     *http.Client
 	ipam       *network.IPAM
-	chrootDir  string        // full chroot root path; removed on Close()
-	done       chan struct{} // closed when cmd.Wait() returns
+	chrootDir  string             // full chroot root path; removed on Close()
+	done       chan struct{}      // closed when cmd.Wait() returns
+	ctx        context.Context    // lifecycle context for the worker
+	cancel     context.CancelFunc // cancelled on Close()
 }
 
 // ID returns the worker ID.
@@ -110,6 +112,9 @@ func (f *FirecrackerWorker) OnCrash(fn func(sessionID string)) {
 // Firecracker process has fully exited before tearing down storage and the
 // chroot, preventing "device busy" errors.
 func (f *FirecrackerWorker) Close() error {
+	if f.cancel != nil {
+		f.cancel()
+	}
 	if f.cmd != nil && f.cmd.Process != nil {
 		_ = f.cmd.Process.Kill()
 		select {
@@ -393,6 +398,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		return nil, fmt.Errorf("failed to connect to guest agent vsock port 5000 within timeout: %v", lastErr)
 	}
 
+	workerCtx, workerCancel := context.WithCancel(context.Background())
 	logPath := filepath.Join(chrootRoot, fmt.Sprintf("%s.log", workerID))
 	logFile, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 
@@ -412,7 +418,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 			Command: finalCmd,
 			Env:     finalEnv,
 		}
-		if err := vsock.Execute(context.Background(), execConn, payload, io.MultiWriter(os.Stdout, logFile)); err != nil {
+		if err := vsock.Execute(workerCtx, execConn, payload, io.MultiWriter(os.Stdout, logFile)); err != nil {
 			fmt.Printf("[host] Failed to execute payload on %s: %v\n", workerID, err)
 		}
 	}()
@@ -439,6 +445,8 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		ipam:       f.IPAM,
 		chrootDir:  chrootRoot,
 		done:       done,
+		ctx:        workerCtx,
+		cancel:     workerCancel,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Storage   StorageConfig   `yaml:"storage"`
 	Resources ResourceConfig  `yaml:"resources"`
 	Binaries  BinaryConfig    `yaml:"binaries"`
+	Jailer    JailerConfig    `yaml:"jailer"`
 	Telemetry TelemetryConfig `yaml:"telemetry"`
 	Cloud     CloudConfig     `yaml:"cloud"`
 }
@@ -45,8 +46,16 @@ type CloudConfig struct {
 
 type BinaryConfig struct {
 	FirecrackerPath string `yaml:"firecracker_path"`
+	JailerPath      string `yaml:"jailer_path"`
 	KernelImagePath string `yaml:"kernel_image_path"`
 	GuestAgentPath  string `yaml:"guest_agent_path"`
+}
+
+// JailerConfig holds parameters for the Firecracker jailer process.
+type JailerConfig struct {
+	UID            int    `yaml:"uid"`
+	GID            int    `yaml:"gid"`
+	ChrootBaseDir  string `yaml:"chroot_base_dir"`
 }
 
 type StorageConfig struct {
@@ -133,11 +142,23 @@ func (c *Config) Validate() error {
 	if c.Binaries.FirecrackerPath == "" {
 		return fmt.Errorf("binaries.firecracker_path is required")
 	}
+	if c.Binaries.JailerPath == "" {
+		return fmt.Errorf("binaries.jailer_path is required")
+	}
 	if c.Binaries.KernelImagePath == "" {
 		return fmt.Errorf("binaries.kernel_image_path is required")
 	}
 	if c.Binaries.GuestAgentPath == "" {
 		return fmt.Errorf("binaries.guest_agent_path is required")
+	}
+	if c.Jailer.UID == 0 {
+		return fmt.Errorf("jailer.uid is required and must be non-zero")
+	}
+	if c.Jailer.GID == 0 {
+		return fmt.Errorf("jailer.gid is required and must be non-zero")
+	}
+	if c.Jailer.ChrootBaseDir == "" {
+		return fmt.Errorf("jailer.chroot_base_dir is required")
 	}
 	if c.Telemetry.MetricsPath == "" || c.Telemetry.MetricsPath[0] != '/' {
 		return fmt.Errorf("telemetry.metrics_path must start with '/'")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,8 +20,13 @@ telemetry:
   metrics_path: /metrics
 binaries:
   firecracker_path: /usr/local/bin/firecracker
+  jailer_path: /usr/local/bin/jailer
   kernel_image_path: /home/user/.herd/resources/vmlinux-v6.1.bin
   guest_agent_path: /home/user/.herd/bin/herd-guest-agent
+jailer:
+  uid: 900
+  gid: 900
+  chroot_base_dir: /srv/jailer
 `
 
 func TestLoad_ValidConfig(t *testing.T) {
@@ -41,6 +46,18 @@ func TestLoad_ValidConfig(t *testing.T) {
 	}
 	if cfg.Telemetry.LogFormat != "json" {
 		t.Fatalf("expected telemetry.log_format=json, got %q", cfg.Telemetry.LogFormat)
+	}
+	if cfg.Binaries.JailerPath != "/usr/local/bin/jailer" {
+		t.Fatalf("expected binaries.jailer_path /usr/local/bin/jailer, got %q", cfg.Binaries.JailerPath)
+	}
+	if cfg.Jailer.UID != 900 {
+		t.Fatalf("expected jailer.uid 900, got %d", cfg.Jailer.UID)
+	}
+	if cfg.Jailer.GID != 900 {
+		t.Fatalf("expected jailer.gid 900, got %d", cfg.Jailer.GID)
+	}
+	if cfg.Jailer.ChrootBaseDir != "/srv/jailer" {
+		t.Fatalf("expected jailer.chroot_base_dir /srv/jailer, got %q", cfg.Jailer.ChrootBaseDir)
 	}
 }
 

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -112,12 +112,14 @@ func CreateTap(name, ipAddr string) error {
 // CreatePointToPointTap creates a new TAP interface and establishes a Point-to-Point peer route.
 // Uses netlink syscalls directly to avoid fork/exec overhead and kernel RTNL lock contention
 // from concurrent `ip` command invocations.
-func CreatePointToPointTap(name, hostIP, guestIP string) error {
+func CreatePointToPointTap(name, hostIP, guestIP string, uid, gid int) error {
 	slog.Info("creating p2p tap interface", "name", name, "host", hostIP, "guest", guestIP)
 
 	tap := &netlink.Tuntap{
 		LinkAttrs: netlink.LinkAttrs{Name: name},
 		Mode:      netlink.TUNTAP_MODE_TAP,
+		Owner:     uint32(uid),
+		Group:     uint32(gid),
 	}
 	if err := netlink.LinkAdd(tap); err != nil {
 		return fmt.Errorf("netlink: add tap %s: %w", name, err)


### PR DESCRIPTION
This pull request introduces significant improvements to how Firecracker VMs are securely isolated and managed using the jailer utility. The main changes include integrating jailer support throughout the CLI and factory logic, updating the initialization workflow to provision the required user/group and chroot directory, and ensuring all per-VM resources are properly cleaned up. The configuration and startup paths have been updated to reflect these changes.

**Jailer integration and chroot management:**

- The `FirecrackerFactory` now launches VMs using the jailer binary, placing each VM in a unique chroot under a configurable base directory. The factory ensures the chroot is created, owned by the correct user/group, and contains all necessary resources (kernel, rootfs device, vsock socket). (`[[1]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR14-R54)`, `[[2]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eL170-R266)`)
- The factory and worker logic have been updated to clean up the entire chroot directory tree when a VM is closed, ensuring no resources are left behind. (`[[1]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR67-R70)`, `[[2]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eL103-R132)`)

**CLI and configuration updates:**

- The `herd init` command now provisions the `firecracker` user/group, creates the jailer chroot base directory, and records the paths and IDs in the config file. It downloads both the firecracker and jailer binaries together and prompts the user for their locations. (`[[1]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L65-R81)`, `[[2]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R106-R123)`, `[[3]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R161-R169)`, `[[4]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L169-R201)`)
- The CLI and test harness (`cmd/herd/exec.go`, `cmd/herd/start.go`, `cmd/test_boot/main.go`) have been updated to pass the new jailer-related configuration to the factory and use the correct per-VM socket paths inside the chroot. (`[[1]](diffhunk://#diff-afd42102a97817a51b9485a52188a850b225af4474dd9d4c1023b8488b2528a3L35-R43)`, `[[2]](diffhunk://#diff-4cf15602fb33e8ebbd1b0c8d5c717d727360ab025c5b527bb64207d3240acd40R191-R198)`, `[[3]](diffhunk://#diff-aa018f4b076f4b59794e9ac140db7da3ab0100ac183bec26d19676bf3886a8f9R42-R49)`)

**Binary download and user provisioning improvements:**

- The Firecracker binary download logic now fetches the official release tarball and extracts both the firecracker and jailer binaries in a single step. (`[cmd/herd/init.goL169-R201](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L169-R201)`)
- A new helper function provisions the `firecracker` user and group with the correct UID/GID, ensuring idempotency and system compatibility. (`[cmd/herd/init.goL207-R312](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L207-R312)`)

**Documentation and code clarity:**

- The codebase has been refactored for clarity, with improved comments and clear separation of concerns regarding chroot management, device node handling, and resource cleanup. (`[[1]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR14-R54)`, `[[2]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eL170-R266)`)

These changes collectively enable secure, unprivileged Firecracker VM isolation using jailer, and provide a robust, automated setup experience for users.