### PR TITLE
adding --yes to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ curl -sSL https://raw.githubusercontent.com/herd-core/herd/main/scripts/install.
 ```bash
 # Prepare the host (loop devices, devmapper, containerd config)
 sudo herd init
+
+# Or in non-interactive mode:
+sudo herd init --yes
 ```
+
 
 ### 3. Start the Daemon
 

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -23,6 +23,17 @@ import (
 
 
 
+var (
+	autoYes        bool
+	fcBinaryPath   string
+	jailerBinPath  string
+	kernelImgPath  string
+	chrootBase     string
+	maxGlobalVMs   int
+	maxGlobalMemMB int64
+	cpuLimitCores  float64
+)
+
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize herd with interactive setup",
@@ -33,6 +44,15 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Skip interactive setup and use defaults/flags")
+	initCmd.Flags().StringVar(&fcBinaryPath, "firecracker-path", "", "Path to firecracker binary")
+	initCmd.Flags().StringVar(&jailerBinPath, "jailer-path", "", "Path to jailer binary")
+	initCmd.Flags().StringVar(&kernelImgPath, "kernel-path", "", "Path to linux kernel image")
+	initCmd.Flags().StringVar(&chrootBase, "chroot-base-dir", "/srv/jailer", "Jailer chroot base directory")
+	initCmd.Flags().IntVar(&maxGlobalVMs, "max-vms", 0, "Max global concurrent MicroVMs")
+	initCmd.Flags().Int64Var(&maxGlobalMemMB, "max-memory", 0, "Max global memory in MB")
+	initCmd.Flags().Float64Var(&cpuLimitCores, "cpu-cores", 0, "CPU limit in cores")
+
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -42,8 +62,11 @@ func runInit() {
 	}
 
 	fmt.Printf("🚀 Welcome to herd initialization (version %s)!\n", config.Version)
-	fmt.Println("This process will help you configure herd and set up the required environment.")
-	fmt.Println()
+	if !autoYes {
+		fmt.Println("This process will help you configure herd and set up the required environment.")
+		fmt.Println()
+	}
+
 	homeDir, err := config.GetTargetHomeDir()
 	if err != nil {
 		log.Fatalf("failed to determine home directory: %v", err)
@@ -52,8 +75,11 @@ func runInit() {
 	binDir := filepath.Join(herdDir, "bin")
 	stateDir := filepath.Join(herdDir, "state")
 
-	fmt.Printf("--- Path Configuration ---\n")
-	fmt.Printf("Base directory: %s\n", herdDir)
+	if !autoYes {
+		fmt.Printf("--- Path Configuration ---\n")
+		fmt.Printf("Base directory: %s\n", herdDir)
+	}
+
 	reader := bufio.NewReader(os.Stdin)
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		log.Fatalf("failed to create bin dir: %v", err)
@@ -64,46 +90,84 @@ func runInit() {
 
 	// 2. Binaries
 	var fcPath, jailerPath string
-	useExistingFC := promptConfirm(reader, "Do you already have Firecracker and jailer installed? (y/n)", false)
-	if useExistingFC {
-		fcPath = promptString(reader, "Path to firecracker binary (default: /usr/local/bin/firecracker)", "/usr/local/bin/firecracker")
-		jailerPath = promptString(reader, "Path to jailer binary (default: /usr/local/bin/jailer)", "/usr/local/bin/jailer")
-	} else {
+	if fcBinaryPath != "" && jailerBinPath != "" {
+		fcPath = fcBinaryPath
+		jailerPath = jailerBinPath
+	} else if autoYes {
+		// Non-interactive default: download if not specified
 		fcPath = filepath.Join(binDir, "firecracker")
 		jailerPath = filepath.Join(binDir, "jailer")
-		fmt.Println("Downloading Firecracker v1.14.3 (includes jailer)...")
-		if err := downloadFirecrackerAndJailer(fcPath, jailerPath); err != nil {
-			log.Fatalf("failed to download firecracker/jailer: %v", err)
+		if _, err := os.Stat(fcPath); os.IsNotExist(err) {
+			fmt.Println("Downloading Firecracker v1.14.3 (includes jailer)...")
+			if err := downloadFirecrackerAndJailer(fcPath, jailerPath); err != nil {
+				log.Fatalf("failed to download firecracker/jailer: %v", err)
+			}
 		}
-		fmt.Printf("✅ Firecracker installed: %s\n", fcPath)
-		fmt.Printf("✅ Jailer installed: %s\n", jailerPath)
+	} else {
+		useExistingFC := promptConfirm(reader, "Do you already have Firecracker and jailer installed? (y/n)", false)
+		if useExistingFC {
+			fcPath = promptString(reader, "Path to firecracker binary (default: /usr/local/bin/firecracker)", "/usr/local/bin/firecracker")
+			jailerPath = promptString(reader, "Path to jailer binary (default: /usr/local/bin/jailer)", "/usr/local/bin/jailer")
+		} else {
+			fcPath = filepath.Join(binDir, "firecracker")
+			jailerPath = filepath.Join(binDir, "jailer")
+			fmt.Println("Downloading Firecracker v1.14.3 (includes jailer)...")
+			if err := downloadFirecrackerAndJailer(fcPath, jailerPath); err != nil {
+				log.Fatalf("failed to download firecracker/jailer: %v", err)
+			}
+			fmt.Printf("✅ Firecracker installed: %s\n", fcPath)
+			fmt.Printf("✅ Jailer installed: %s\n", jailerPath)
+		}
 	}
 
 	// Guest Agent - Download pre-compiled binary
 	agentPath := filepath.Join(binDir, "herd-guest-agent")
-	fmt.Println("Downloading pre-compiled herd-guest-agent...")
-	if err := downloadGuestAgent(agentPath); err != nil {
-		log.Fatalf("failed to download guest agent: %v", err)
+	if _, err := os.Stat(agentPath); os.IsNotExist(err) {
+		fmt.Println("Downloading pre-compiled herd-guest-agent...")
+		if err := downloadGuestAgent(agentPath); err != nil {
+			log.Fatalf("failed to download guest agent: %v", err)
+		}
+		if !autoYes {
+			fmt.Printf("✅ Download complete: %s\n", agentPath)
+		}
 	}
-	fmt.Printf("✅ Download complete: %s\n", agentPath)
 
 	// 3. Kernel
 	var kernelPath string
-	useExistingKernel := promptConfirm(reader, "Do you have your own Linux kernel image for Firecracker? (y/n)", false)
-	if useExistingKernel {
-		kernelPath = promptString(reader, "Enter path to kernel image (e.g., /path/to/vmlinux)", "")
-	} else {
+	if kernelImgPath != "" {
+		kernelPath = kernelImgPath
+	} else if autoYes {
 		kernelPath = filepath.Join(stateDir, "vmlinux-v6.1.bin")
-		fmt.Printf("Downloading pre-compiled kernel to %s...\n", kernelPath)
-		if err := downloadKernel(kernelPath); err != nil {
-			log.Fatalf("failed to download kernel: %v", err)
+		if _, err := os.Stat(kernelPath); os.IsNotExist(err) {
+			fmt.Printf("Downloading pre-compiled kernel to %s...\n", kernelPath)
+			if err := downloadKernel(kernelPath); err != nil {
+				log.Fatalf("failed to download kernel: %v", err)
+			}
+		}
+	} else {
+		useExistingKernel := promptConfirm(reader, "Do you have your own Linux kernel image for Firecracker? (y/n)", false)
+		if useExistingKernel {
+			kernelPath = promptString(reader, "Enter path to kernel image (e.g., /path/to/vmlinux)", "")
+		} else {
+			kernelPath = filepath.Join(stateDir, "vmlinux-v6.1.bin")
+			fmt.Printf("Downloading pre-compiled kernel to %s...\n", kernelPath)
+			if err := downloadKernel(kernelPath); err != nil {
+				log.Fatalf("failed to download kernel: %v", err)
+			}
 		}
 	}
-	fmt.Println()
+	if !autoYes {
+		fmt.Println()
+	}
 
 	// 4. Jailer chroot base dir
-	fmt.Println("--- Jailer Configuration ---")
-	chrootBaseDir := promptString(reader, "Jailer chroot base dir (default: /srv/jailer)", "/srv/jailer")
+	var chrootBaseDir string
+	if autoYes {
+		chrootBaseDir = chrootBase
+	} else {
+		fmt.Println("--- Jailer Configuration ---")
+		chrootBaseDir = promptString(reader, "Jailer chroot base dir (default: /srv/jailer)", "/srv/jailer")
+	}
 
 	// The chrootBaseDir is owned by root:root 0755 so all dynamically-leased UIDs
 	// can traverse into it. Per-VM isolation is enforced at the per-VM
@@ -111,14 +175,18 @@ func runInit() {
 	if err := os.MkdirAll(chrootBaseDir, 0755); err != nil {
 		log.Fatalf("failed to create chroot base dir: %v", err)
 	}
-	fmt.Printf("✅ Chroot base dir ready: %s (owned by root)\n", chrootBaseDir)
+	if !autoYes {
+		fmt.Printf("✅ Chroot base dir ready: %s (owned by root)\n", chrootBaseDir)
+	}
 
 	const (
 		uidPoolStart = 300000
 		uidPoolSize  = 200
 	)
-	fmt.Printf("UID pool: [%d, %d) — one unique UID per concurrent MicroVM\n", uidPoolStart, uidPoolStart+uidPoolSize)
-	fmt.Println()
+	if !autoYes {
+		fmt.Printf("UID pool: [%d, %d) — one unique UID per concurrent MicroVM\n", uidPoolStart, uidPoolStart+uidPoolSize)
+		fmt.Println()
+	}
 
 	// 4. Resource Limits
 	sysInfo, err := system.GetInfo()
@@ -133,11 +201,34 @@ func runInit() {
 		defaultCPUCores = 1
 	}
 
-	fmt.Printf("--- Resource Configuration ---\n")
-	maxVMs := promptInt(reader, fmt.Sprintf("Max global VMs (default: %d)", defaultMaxVMs), defaultMaxVMs)
-	maxMem := promptInt64(reader, fmt.Sprintf("Max global memory MB (default: %d)", defaultMaxMem), defaultMaxMem)
-	cpuCores := promptFloat(reader, fmt.Sprintf("CPU limit cores (default: %.1f)", defaultCPUCores), defaultCPUCores)
-	fmt.Println()
+	var maxVMs int
+	var maxMem int64
+	var cpuCores float64
+
+	if autoYes {
+		if maxGlobalVMs > 0 {
+			maxVMs = maxGlobalVMs
+		} else {
+			maxVMs = defaultMaxVMs
+		}
+		if maxGlobalMemMB > 0 {
+			maxMem = maxGlobalMemMB
+		} else {
+			maxMem = defaultMaxMem
+		}
+		if cpuLimitCores > 0 {
+			cpuCores = cpuLimitCores
+		} else {
+			cpuCores = defaultCPUCores
+		}
+	} else {
+		fmt.Printf("--- Resource Configuration ---\n")
+		maxVMs = promptInt(reader, fmt.Sprintf("Max global VMs (default: %d)", defaultMaxVMs), defaultMaxVMs)
+		maxMem = promptInt64(reader, fmt.Sprintf("Max global memory MB (default: %d)", defaultMaxMem), defaultMaxMem)
+		cpuCores = promptFloat(reader, fmt.Sprintf("CPU limit cores (default: %.1f)", defaultCPUCores), defaultCPUCores)
+		fmt.Println()
+	}
+
 
 	// 5. Config Generation
 	cfg := config.Config{

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -102,6 +102,11 @@ func runInit() {
 			if err := downloadFirecrackerAndJailer(fcPath, jailerPath); err != nil {
 				log.Fatalf("failed to download firecracker/jailer: %v", err)
 			}
+		} else if _, err := os.Stat(jailerPath); os.IsNotExist(err) {
+			fmt.Println("Downloading Firecracker v1.14.3 (includes jailer)...")
+			if err := downloadFirecrackerAndJailer(fcPath, jailerPath); err != nil {
+				log.Fatalf("failed to download firecracker/jailer: %v", err)
+			}
 		}
 	} else {
 		useExistingFC := promptConfirm(reader, "Do you already have Firecracker and jailer installed? (y/n)", false)

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -36,7 +36,7 @@ var (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize herd with interactive setup",
+	Short: "Initialize herd (interactive or non-interactive with --yes)",
 	Long:  `Guides you through the process of setting up herd, including kernel selection, resource limits, and environment bootstrapping.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runInit()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,13 +7,23 @@ The Herd CLI (`herd`) is the primary interface for managing the daemon and inter
 ## 🛠️ Infrastructure Commands
 
 ### `herd init`
-Interactive setup for your host environment.
-- **Usage**: `sudo herd init`
+Initialize herd on your host environment.
+- **Usage**: `sudo herd init [flags]`
+- **Flags**:
+    - `-y, --yes`: Skip interactive setup and use defaults/flags.
+    - `--firecracker-path <path>`: Custom path to Firecracker binary.
+    - `--jailer-path <path>`: Custom path to jailer binary.
+    - `--kernel-path <path>`: Custom path to Linux kernel image.
+    - `--chroot-base-dir <path>`: Jailer chroot base directory (default: `/srv/jailer`).
+    - `--max-vms <int>`: Max global concurrent MicroVMs.
+    - `--max-memory <int>`: Max global memory in MB.
+    - `--cpu-cores <float>`: CPU limit in cores.
 - **Actions**:
-    - Prompts for resource limits (CPU, Memory).
-    - Downloads `firecracker` and `herd-guest-agent`.
+    - Prompts for resource limits (CPU, Memory) if not in non-interactive mode.
+    - Downloads `firecracker`, `jailer`, and `herd-guest-agent` if not found.
     - Bootstraps `devmapper` storage and host NAT networking.
     - Generates `herd.yaml`.
+
 
 ### `herd teardown`
 Completely removes Herd state from the host.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,13 @@ Before you can spawn microVMs, Herd needs to prepare your host system's storage 
 sudo herd init
 ```
 
+Alternatively, you can run in **non-interactive mode** (useful for scripts and CI/CD):
+
+```bash
+sudo herd init --yes
+```
+
+
 **What this does**:
 - Sets up the `devmapper` thin-pool for high-speed rootfs snapshotting.
 - Provisions the chroot base directory (`/srv/jailer`) owned by `root`.


### PR DESCRIPTION
This pull request adds a non-interactive mode to the `herd init` command, allowing users to initialize Herd with default values or custom flags, which is especially useful for automation and CI/CD pipelines. The changes introduce new command-line flags for resource and path configuration, update documentation to reflect these enhancements, and ensure that all interactive prompts are bypassed when the `--yes` flag is used.

**New non-interactive mode and CLI enhancements:**

* Added the `--yes` (`-y`) flag to `herd init` to skip interactive prompts and use defaults or provided flags. Several new flags were introduced for specifying paths and resource limits: `--firecracker-path`, `--jailer-path`, `--kernel-path`, `--chroot-base-dir`, `--max-vms`, `--max-memory`, and `--cpu-cores`. [[1]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R26-R36) [[2]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R47-R55)

* Updated `cmd/herd/init.go` logic to support non-interactive initialization: when `--yes` is set, prompts are skipped, binaries and kernel are downloaded if not present, and resource limits are set from flags or defaults. [[1]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R65-R69) [[2]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R78-R82) [[3]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R93-R106) [[4]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R121-R147) [[5]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R158-R189) [[6]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R204-R231)

**Documentation updates:**

* Updated `docs/cli.md` to document the new non-interactive mode and all new flags for `herd init`.

* Updated `docs/getting-started.md` and `README.md` to show usage examples for non-interactive initialization with `--yes`. [[1]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R49-R55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R58)

These changes make it much easier to automate Herd setup and integrate it into scripts and CI/CD workflows.