### PR TITLE
host port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Herd implements four critical layers that bridge the gap between "hardware" and 
 - **L7 "Wake-on-Request" Proxy**: A high-speed reverse proxy that intercepts HTTP requests, cold-boots the corresponding VM (if needed [WIP]), and tunnels the traffic inside.
 - **Automated IPAM**: Zero-config networking pool that manages subnets, TAP interfaces, and NAT routing.
 - **Guest Agent Execution**: Injects `herd-guest-agent` as PID 1 to handle internal OS setup and workload execution.
+- **Port Publishing (Hybrid Mode)**: Supports both deterministic host port binding (`-p 80:80`) and dynamic ephemeral allocation for secure, multi-tenant ingress.
 - **Dynamic UID Isolation**: Leverages the Firecracker jailer to drop process privileges into a unique, per-VM UID/GID leased from a dynamic pool. This ensures every tenant runs in a distinct DAC security domain, providing absolute lateral movement protection on multi-tenant hosts.
 
 ## 🛰️ The "Brutal Difference"

--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/herd-core/herd/internal/config"
@@ -20,6 +21,7 @@ var (
 	absoluteDeployTimeout int
 	deployCommand []string
 	deployEnv     []string
+	deployPublish []string
 )
 
 var deployCmd = &cobra.Command{
@@ -51,6 +53,51 @@ var deployCmd = &cobra.Command{
 			}
 			req["env"] = envMap
 		}
+
+		if len(deployPublish) > 0 {
+			mappings := make([]map[string]any, 0, len(deployPublish))
+			for _, p := range deployPublish {
+				protocol := "tcp"
+				addrPart := p
+				if protoParts := strings.Split(p, "/"); len(protoParts) == 2 {
+					addrPart = protoParts[0]
+					protocol = strings.ToLower(protoParts[1])
+				}
+
+				m := map[string]any{
+					"protocol": protocol,
+				}
+				parts := strings.Split(addrPart, ":")
+
+				if len(parts) == 2 {
+					// host_port:guest_port OR :guest_port
+					if parts[0] == "" {
+						// :80
+						m["host_port"] = 0
+						m["host_interface"] = "0.0.0.0"
+					} else {
+						// 8080:80
+						hPort, _ := strconv.Atoi(parts[0])
+						m["host_port"] = hPort
+						m["host_interface"] = "0.0.0.0"
+					}
+					gPort, _ := strconv.Atoi(parts[1])
+					m["guest_port"] = gPort
+				} else if len(parts) == 3 {
+					// interface:host_port:guest_port
+					m["host_interface"] = parts[0]
+					hPort, _ := strconv.Atoi(parts[1])
+					gPort, _ := strconv.Atoi(parts[2])
+					m["host_port"] = hPort
+					m["guest_port"] = gPort
+				} else {
+					log.Fatalf("invalid publish format %q: expected [[interface:]host_port]:guest_port[/protocol]", p)
+				}
+				mappings = append(mappings, m)
+			}
+			req["port_mappings"] = mappings
+		}
+
 		reqBody, _ := json.Marshal(req)
 
 		url := fmt.Sprintf("http://%s/v1/sessions", cfg.Network.ControlBind)
@@ -87,4 +134,5 @@ func init() {
 	deployCmd.Flags().StringArrayVarP(&deployEnv, "env", "e", nil, "Set environment variables (e.g. -e POSTGRES_PASSWORD=secret)")
 	deployCmd.Flags().IntVar(&deployTimeout, "timeout", 0, "Idle timeout in seconds")
 	deployCmd.Flags().IntVar(&absoluteDeployTimeout, "absolute-timeout", 0, "Absolute timeout in seconds")
+	deployCmd.Flags().StringSliceVarP(&deployPublish, "publish", "p", nil, "Publish a port (e.g. 8080:80, :80, 1.2.3.4:8080:80)")
 }

--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -77,17 +77,29 @@ var deployCmd = &cobra.Command{
 						m["host_interface"] = "0.0.0.0"
 					} else {
 						// 8080:80
-						hPort, _ := strconv.Atoi(parts[0])
+						hPort, err := strconv.Atoi(parts[0])
+						if err != nil {
+							log.Fatalf("invalid host port %q in publish flag %q: %v", parts[0], p, err)
+						}
 						m["host_port"] = hPort
 						m["host_interface"] = "0.0.0.0"
 					}
-					gPort, _ := strconv.Atoi(parts[1])
+					gPort, err := strconv.Atoi(parts[1])
+					if err != nil {
+						log.Fatalf("invalid guest port %q in publish flag %q: %v", parts[1], p, err)
+					}
 					m["guest_port"] = gPort
 				} else if len(parts) == 3 {
 					// interface:host_port:guest_port
 					m["host_interface"] = parts[0]
-					hPort, _ := strconv.Atoi(parts[1])
-					gPort, _ := strconv.Atoi(parts[2])
+					hPort, err := strconv.Atoi(parts[1])
+					if err != nil {
+						log.Fatalf("invalid host port %q in publish flag %q: %v", parts[1], p, err)
+					}
+					gPort, err := strconv.Atoi(parts[2])
+					if err != nil {
+						log.Fatalf("invalid guest port %q in publish flag %q: %v", parts[2], p, err)
+					}
 					m["host_port"] = hPort
 					m["guest_port"] = gPort
 				} else {
@@ -124,6 +136,24 @@ var deployCmd = &cobra.Command{
 		fmt.Printf("Session ID: %v\n", result["session_id"])
 		fmt.Printf("Internal IP: %v\n", result["internal_ip"])
 		fmt.Printf("Proxy URL: %v\n", result["proxy_address"])
+		// Print port mappings so the user knows what was assigned (especially for random `:port` allocation)
+		if mappings, ok := result["port_mappings"]; ok && mappings != nil {
+			if ms, ok := mappings.([]any); ok && len(ms) > 0 {
+				fmt.Println("Port Mappings:")
+				for _, m := range ms {
+					if mm, ok := m.(map[string]any); ok {
+						protocol := mm["protocol"]
+						hostPort := mm["host_port"]
+						guestPort := mm["guest_port"]
+						if mm["host_interface"] != nil && mm["host_interface"] != "0.0.0.0" {
+							fmt.Printf("  %v:%v -> VM:%v/%v\n", mm["host_interface"], hostPort, guestPort, protocol)
+						} else {
+							fmt.Printf("  0.0.0.0:%v -> VM:%v/%v\n", hostPort, guestPort, protocol)
+						}
+					}
+				}
+			}
+		}
 	},
 }
 

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -244,6 +244,8 @@ func runInit() {
 		Network: config.NetworkConfig{
 			ControlBind: "127.0.0.1:8081",
 			DataBind:    "127.0.0.1:8080",
+			EphemeralPortStart: 10000,
+			EphemeralPortEnd: 39999,
 		},
 		Storage: config.StorageConfig{
 			StateDir:        stateDir,

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -192,6 +192,8 @@ func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {
 		return nil, fmt.Errorf("create uid pool: %w", err)
 	}
 
+	portMgr := network.NewPortManager(cfg.Network.EphemeralPortStart, cfg.Network.EphemeralPortEnd)
+
 	factory := &herd.FirecrackerFactory{
 		FirecrackerPath:     cfg.Binaries.FirecrackerPath,
 		JailerPath:          cfg.Binaries.JailerPath,
@@ -200,6 +202,7 @@ func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {
 		Storage:             mgr,
 		IPAM:                ipam,
 		UIDPool:             uidPool,
+		PortManager:         portMgr,
 		JailerChrootBaseDir: cfg.Jailer.ChrootBaseDir,
 	}
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,13 @@ Quickly spawn a new microVM session.
     - `--cmd`: Command to run (comma-separated).
     - `-e`, `--env`: Environment variables.
     - `--timeout`: Idle timeout in seconds (default: `300`).
+    - `-p`, `--publish`: Publish a guest port to the host.
+        - Format: `[host_interface:]host_port:guest_port[/protocol]`
+        - Examples:
+            - `8080:80` (Bind all interfaces)
+            - `127.0.0.1:8080:80` (Localhost only)
+            - `:80` (Random host port allocation)
+            - `53:53/udp` (UDP mapping)
 
 ### `herd exec`
 Open an interactive shell inside a running microVM.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,8 @@ Controls the binding addresses for the Control and Data planes.
 | :--- | :--- | :--- |
 | `control_bind` | REST API address for management. | `127.0.0.1:8081` |
 | `data_bind` | HTTP Proxy address for traffic. | `127.0.0.1:8080` |
+| `ephemeral_port_start` | Start of the random port range. | `10000` |
+| `ephemeral_port_end` | End of the random port range. | `39999` |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,3 +92,20 @@ Herd will automatically:
 5.  Provide you with a **Session ID** and a **Proxy URL**.
 
 You can now access your application via the proxy, which intelligently routes traffic to your dedicated microVM.
+
+---
+
+## 🌐 5. Port Publishing (Hybrid Mode)
+
+If you need to expose a specific port (e.g., for a database or a web server on a custom port), use the `--publish` flag:
+
+```bash
+# Explicitly map host port 5432 to guest port 5432
+herd deploy --image postgres:latest -e POSTGRES_PASSWORD=test --publish 5432:5432
+
+# Mapping to a random available host port
+herd deploy --image nginx:latest --publish :80
+```
+
+**Network Prerequisites**:
+For loopback access (`127.0.0.1`) to work with published ports, Herd automatically enables `net.ipv4.conf.all.route_localnet=1` during initialization. This allows loopback traffic to be routed through the NAT stack to your microVMs.

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -511,7 +511,7 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 		hostPort := pm.HostPort
 		if f.PortManager != nil {
 			var err error
-			hostPort, err = f.PortManager.Allocate(pm.HostPort, pm.Protocol, workerID)
+			hostPort, err = f.PortManager.Allocate(pm.HostPort, pm.Protocol, pm.HostInterface, workerID)
 			if err != nil {
 				slog.Warn("failed to allocate port", "id", workerID, "requested", pm.HostPort, "error", err)
 				continue

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -70,8 +70,9 @@ type FirecrackerWorker struct {
 	done       chan struct{}       // closed when cmd.Wait() returns
 	ctx        context.Context    // lifecycle context for the worker
 	cancel     context.CancelFunc // cancelled on Close()
-	leasedUID  int                // UID leased from UIDPool for this VM
-	uidPool    *uid.Pool          // pool to return the UID to on Close()
+	leasedUID    int                // UID leased from UIDPool for this VM
+	uidPool      *uid.Pool          // pool to return the UID to on Close()
+	portMappings []PortMapping      // active port forwards on the host
 }
 
 // ID returns the worker ID.
@@ -92,6 +93,11 @@ func (f *FirecrackerWorker) Address() string {
 // VsockUDSPath is the host-visible Unix socket Firecracker exposes for vsock.
 func (f *FirecrackerWorker) VsockUDSPath() string {
 	return f.socketPath
+}
+
+// PortMappings returns the active port forwards for this worker.
+func (f *FirecrackerWorker) PortMappings() []PortMapping {
+	return f.portMappings
 }
 
 // Client returns the HTTP client.
@@ -157,6 +163,10 @@ func (f *FirecrackerWorker) Close() error {
 		if err := f.uidPool.Return(f.leasedUID); err != nil {
 			slog.Error("failed to return uid to pool", "vmID", f.id, "uid", f.leasedUID, "error", err)
 		}
+	}
+
+	for _, pm := range f.portMappings {
+		_ = network.RemovePortMapping(pm.HostInterface, pm.HostPort, f.guestIP, pm.GuestPort, pm.Protocol)
 	}
 
 	return nil
@@ -490,21 +500,44 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 
 	log.Printf("[spawn:%s] TOTAL            %v", workerID, time.Since(spawnStart))
 
+	// Apply Port Mappings
+	activeMappings := make([]PortMapping, 0, len(config.PortMappings))
+	for _, pm := range config.PortMappings {
+		hostPort := pm.HostPort
+		if hostPort == 0 {
+			var err error
+			hostPort, err = network.FindAvailablePort(pm.HostInterface)
+			if err != nil {
+				slog.Warn("failed to find available port for mapping", "id", workerID, "error", err)
+				continue
+			}
+		}
+
+		if err := network.AddPortMapping(pm.HostInterface, hostPort, guestIP, pm.GuestPort, pm.Protocol); err != nil {
+			slog.Warn("failed to add port mapping", "id", workerID, "error", err)
+			continue
+		}
+
+		pm.HostPort = hostPort
+		activeMappings = append(activeMappings, pm)
+	}
+
 	return &FirecrackerWorker{
-		id:         workerID,
-		socketPath: socketPath,
-		tapName:    tapName,
-		guestIP:    guestIP,
-		cmd:        cmd,
-		client:     agentClient,
-		storage:    f.Storage,
-		ipam:       f.IPAM,
-		chrootDir:  chrootRoot,
-		done:       done,
-		ctx:        workerCtx,
-		cancel:     workerCancel,
-		leasedUID:  leasedUID,
-		uidPool:    f.UIDPool,
+		id:           workerID,
+		socketPath:   socketPath,
+		tapName:      tapName,
+		guestIP:      guestIP,
+		cmd:          cmd,
+		client:       agentClient,
+		storage:      f.Storage,
+		ipam:         f.IPAM,
+		chrootDir:    chrootRoot,
+		done:         done,
+		ctx:          workerCtx,
+		cancel:       workerCancel,
+		leasedUID:    leasedUID,
+		uidPool:      f.UIDPool,
+		portMappings: activeMappings,
 	}, nil
 }
 

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -513,17 +513,36 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 			var err error
 			hostPort, err = f.PortManager.Allocate(pm.HostPort, pm.Protocol, pm.HostInterface, workerID)
 			if err != nil {
-				slog.Warn("failed to allocate port", "id", workerID, "requested", pm.HostPort, "error", err)
-				continue
+				// Any port allocation failure is now a hard error. 
+				// Caller didn't get the network profile they requested; fail the Spawn entirely.
+				network.DeleteTap(tapName)
+				f.IPAM.Release(guestIP)
+				_ = cmd.Process.Kill()
+				_ = os.RemoveAll(chrootRoot)
+				_ = f.Storage.Teardown(ctx, workerID)
+				f.UIDPool.Return(leasedUID) //nolint:errcheck
+				return nil, fmt.Errorf("port allocation failed for mapping %d->%d: %w", pm.HostPort, pm.GuestPort, err)
 			}
 		}
 
 		if err := network.AddPortMapping(pm.HostInterface, hostPort, guestIP, pm.GuestPort, pm.Protocol); err != nil {
-			slog.Warn("failed to add port mapping", "id", workerID, "error", err)
 			if f.PortManager != nil {
 				f.PortManager.Release(hostPort)
 			}
-			continue
+			// Clean up any mappings/rules we've already applied for this VM.
+			for _, applied := range activeMappings {
+				_ = network.RemovePortMapping(applied.HostInterface, applied.HostPort, guestIP, applied.GuestPort, applied.Protocol)
+				if f.PortManager != nil {
+					f.PortManager.Release(applied.HostPort)
+				}
+			}
+			network.DeleteTap(tapName)
+			f.IPAM.Release(guestIP)
+			_ = cmd.Process.Kill()
+			_ = os.RemoveAll(chrootRoot)
+			_ = f.Storage.Teardown(ctx, workerID)
+			f.UIDPool.Return(leasedUID) //nolint:errcheck
+			return nil, fmt.Errorf("iptables setup failed for mapping %d->%d: %w", pm.HostPort, pm.GuestPort, err)
 		}
 
 		pm.HostPort = hostPort

--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -37,6 +37,7 @@ type FirecrackerFactory struct {
 
 	Storage *storage.Manager
 	IPAM    *network.IPAM
+	PortManager *network.PortManager
 
 	// UIDPool is the per-VM UID/GID allocator. Each Spawn leases a unique UID
 	// from the pool; Close returns it. This guarantees every concurrent microVM
@@ -73,6 +74,7 @@ type FirecrackerWorker struct {
 	leasedUID    int                // UID leased from UIDPool for this VM
 	uidPool      *uid.Pool          // pool to return the UID to on Close()
 	portMappings []PortMapping      // active port forwards on the host
+	portManager  *network.PortManager // manager to release ports to on Close()
 }
 
 // ID returns the worker ID.
@@ -167,6 +169,9 @@ func (f *FirecrackerWorker) Close() error {
 
 	for _, pm := range f.portMappings {
 		_ = network.RemovePortMapping(pm.HostInterface, pm.HostPort, f.guestIP, pm.GuestPort, pm.Protocol)
+		if f.portManager != nil {
+			f.portManager.Release(pm.HostPort)
+		}
 	}
 
 	return nil
@@ -504,17 +509,20 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	activeMappings := make([]PortMapping, 0, len(config.PortMappings))
 	for _, pm := range config.PortMappings {
 		hostPort := pm.HostPort
-		if hostPort == 0 {
+		if f.PortManager != nil {
 			var err error
-			hostPort, err = network.FindAvailablePort(pm.HostInterface)
+			hostPort, err = f.PortManager.Allocate(pm.HostPort, pm.Protocol, workerID)
 			if err != nil {
-				slog.Warn("failed to find available port for mapping", "id", workerID, "error", err)
+				slog.Warn("failed to allocate port", "id", workerID, "requested", pm.HostPort, "error", err)
 				continue
 			}
 		}
 
 		if err := network.AddPortMapping(pm.HostInterface, hostPort, guestIP, pm.GuestPort, pm.Protocol); err != nil {
 			slog.Warn("failed to add port mapping", "id", workerID, "error", err)
+			if f.PortManager != nil {
+				f.PortManager.Release(hostPort)
+			}
 			continue
 		}
 
@@ -523,21 +531,22 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	}
 
 	return &FirecrackerWorker{
-		id:           workerID,
-		socketPath:   socketPath,
-		tapName:      tapName,
-		guestIP:      guestIP,
-		cmd:          cmd,
-		client:       agentClient,
-		storage:      f.Storage,
-		ipam:         f.IPAM,
-		chrootDir:    chrootRoot,
-		done:         done,
-		ctx:          workerCtx,
-		cancel:       workerCancel,
-		leasedUID:    leasedUID,
-		uidPool:      f.UIDPool,
-		portMappings: activeMappings,
+		id:            workerID,
+		socketPath:    socketPath,
+		tapName:       tapName,
+		guestIP:       guestIP,
+		cmd:           cmd,
+		client:        agentClient,
+		storage:       f.Storage,
+		ipam:          f.IPAM,
+		chrootDir:     chrootRoot,
+		done:          done,
+		ctx:           workerCtx,
+		cancel:        workerCancel,
+		leasedUID:     leasedUID,
+		uidPool:       f.UIDPool,
+		portMappings:  activeMappings,
+		portManager:   f.PortManager,
 	}, nil
 }
 

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -114,7 +114,12 @@ func (c *Client) commandLoop(ctx context.Context) {
 		}
 
 		log.Printf("Received Cloud Command: %s (ID: %s)", cmd.Action, cmd.CommandId)
-		// TODO: Dispatch to internal worker/pool
+		
+		// TODO (Implementation Detail):
+		// When cmd.Action == "boot_vm", parse 'params' for 'image' and 'publish' port mappings.
+		// Example: publish=eth0:8080:80:tcp,eth1:30042:80:tcp
+		// Map these to herd.TenantConfig and call c.pool.Acquire(ctx, sessionID, config).
+		// This requires passing the herd.Pool into NewClient() in cmd/herd/start.go.
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,8 +74,10 @@ type StorageConfig struct {
 }
 
 type NetworkConfig struct {
-	ControlBind string `yaml:"control_bind"`
-	DataBind    string `yaml:"data_bind"`
+	ControlBind        string `yaml:"control_bind"`
+	DataBind           string `yaml:"data_bind"`
+	EphemeralPortStart int    `yaml:"ephemeral_port_start"`
+	EphemeralPortEnd   int    `yaml:"ephemeral_port_end"`
 }
 
 type ResourceConfig struct {
@@ -121,6 +123,12 @@ func (c *Config) applyDefaults() {
 	if c.Telemetry.MetricsPath == "" {
 		c.Telemetry.MetricsPath = "/metrics"
 	}
+	if c.Network.EphemeralPortStart == 0 {
+		c.Network.EphemeralPortStart = 10000
+	}
+	if c.Network.EphemeralPortEnd == 0 {
+		c.Network.EphemeralPortEnd = 39999
+	}
 }
 
 func (c *Config) Validate() error {
@@ -135,6 +143,15 @@ func (c *Config) Validate() error {
 	}
 	if err := validateDataBind(c.Network.DataBind); err != nil {
 		return fmt.Errorf("network.data_bind invalid: %w", err)
+	}
+	if c.Network.EphemeralPortStart < 1 || c.Network.EphemeralPortStart > 65535 {
+		return fmt.Errorf("network.ephemeral_port_start must be between 1 and 65535")
+	}
+	if c.Network.EphemeralPortEnd < 1 || c.Network.EphemeralPortEnd > 65535 {
+		return fmt.Errorf("network.ephemeral_port_end must be between 1 and 65535")
+	}
+	if c.Network.EphemeralPortStart > c.Network.EphemeralPortEnd {
+		return fmt.Errorf("network.ephemeral_port_start must be <= network.ephemeral_port_end")
 	}
 	if c.Resources.MaxGlobalVMs < 1 {
 		return fmt.Errorf("resources.max_global_vms must be >= 1")

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -138,20 +138,22 @@ func (h *ControlPlaneHandler) handleHeartbeat(w http.ResponseWriter, r *http.Req
 	// SessionCreateRequest is the JSON body for POST /v1/sessions
 	// It acts as the TenantDeploymentConfig.
 	type SessionCreateRequest struct {
-		Image              string            `json:"image"`
-		Command            []string          `json:"command,omitempty"`
-		Env                map[string]string `json:"env,omitempty"`
-		IdleTimeoutSeconds int               `json:"idle_timeout_seconds,omitempty"`
-		TTLSeconds         int               `json:"ttl_seconds,omitempty"`
-		HealthInterval     string            `json:"health_interval,omitempty"`
-		Warm               bool              `json:"warm,omitempty"`
+		Image              string             `json:"image"`
+		Command            []string           `json:"command,omitempty"`
+		Env                map[string]string  `json:"env,omitempty"`
+		IdleTimeoutSeconds int                `json:"idle_timeout_seconds,omitempty"`
+		TTLSeconds         int                `json:"ttl_seconds,omitempty"`
+		HealthInterval     string             `json:"health_interval,omitempty"`
+		Warm               bool               `json:"warm,omitempty"`
+		PortMappings       []herd.PortMapping `json:"port_mappings,omitempty"`
 	}
 
 	// SessionCreateResponse is the JSON response
 	type SessionCreateResponse struct {
-		SessionID    string `json:"session_id"`
-		InternalIP   string `json:"internal_ip"`
-		ProxyAddress string `json:"proxy_address"`
+		SessionID    string             `json:"session_id"`
+		InternalIP   string             `json:"internal_ip"`
+		ProxyAddress string             `json:"proxy_address"`
+		PortMappings []herd.PortMapping `json:"port_mappings,omitempty"`
 	}
 
 func (h *ControlPlaneHandler) handleCreateSession(w http.ResponseWriter, r *http.Request) {
@@ -182,6 +184,7 @@ func (h *ControlPlaneHandler) handleCreateSession(w http.ResponseWriter, r *http
 		IdleTimeoutSeconds: req.IdleTimeoutSeconds,
 		TTLSeconds:         req.TTLSeconds,
 		HealthInterval:     req.HealthInterval,
+		PortMappings:       req.PortMappings,
 	}
 
 	session, err := h.pool.Acquire(r.Context(), sessionID, tenantConfig)
@@ -206,6 +209,12 @@ func (h *ControlPlaneHandler) handleCreateSession(w http.ResponseWriter, r *http
 		SessionID:    sessionID,
 		InternalIP:   internalIP,
 		ProxyAddress: h.proxyAddress,
+		PortMappings: req.PortMappings,
+	}
+
+	// If the worker has updated port mappings (e.g. random ports assigned), use those
+	if fw, ok := session.Worker.(interface{ PortMappings() []herd.PortMapping }); ok {
+		resp.PortMappings = fw.PortMappings()
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -246,7 +246,8 @@ func RemovePortMapping(hostInterface string, hostPort int, guestIP string, guest
 		_ = runCmd("iptables", outputArgs...)
 	}
 
-	fwdArgs := []string{"-D", "FORWARD", "-p", protocol, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
+	// Must exactly match the rule installed in AddPortMapping (including the negated source).
+	fwdArgs := []string{"-D", "FORWARD", "-p", protocol, "!", "-s", Subnet, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
 	_ = runCmd("iptables", fwdArgs...)
 
 	slog.Info("port mapping removed", "host", hostInterface, "hPort", hostPort, "gIP", guestIP, "gPort", guestPort)

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -29,6 +29,12 @@ func Bootstrap() error {
 		return err
 	}
 
+	// Allow loopback traffic (127.0.0.1) to be routed through iptables NAT,
+	// enabling the host to access published ports via localhost.
+	if err := runCmd("sysctl", "-w", "net.ipv4.conf.all.route_localnet=1"); err != nil {
+		return err
+	}
+
 	if err := runCmd("iptables", "-t", "nat", "-A", "POSTROUTING", "-o", iface, "-s", Subnet, "-j", "MASQUERADE"); err != nil {
 		return err
 	}

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -36,6 +36,12 @@ func Bootstrap() error {
 		return err
 	}
 
+	// Hairpin NAT Masquerade: Ensure host-to-VM traffic (e.g. from 127.0.0.1) 
+	// is masqueraded so the VM sees the host's bridge IP as source.
+	if err := runCmd("iptables", "-t", "nat", "-A", "POSTROUTING", "-d", Subnet, "-m", "addrtype", "--src-type", "LOCAL", "-j", "MASQUERADE"); err != nil {
+		return err
+	}
+
 	// Drop all traffic from the MicroVM subnet to RFC 1918 private subnets for isolation
 	for _, privNet := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
 		if err := runCmd("iptables", "-A", "FORWARD", "-s", Subnet, "-d", privNet, "-j", "DROP"); err != nil {
@@ -62,6 +68,7 @@ func Teardown() error {
 
 	// We intentionally suppress errors on teardown so that the failure to delete one rule doesn't halt the rest.
 	_ = runCmd("iptables", "-t", "nat", "-D", "POSTROUTING", "-o", iface, "-s", Subnet, "-j", "MASQUERADE")
+	_ = runCmd("iptables", "-t", "nat", "-D", "POSTROUTING", "-d", Subnet, "-m", "addrtype", "--src-type", "LOCAL", "-j", "MASQUERADE")
 	_ = runCmd("iptables", "-D", "FORWARD", "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT")
 
 	// Remove RFC 1918 drop rules
@@ -169,6 +176,9 @@ func AddPortMapping(hostInterface string, hostPort int, guestIP string, guestPor
 		} else {
 			dnatArgs = append(dnatArgs, "-i", hostInterface)
 		}
+	} else {
+		// Specificity: only match packets destined for the host itself (Public IP, 127.0.0.1, etc.)
+		dnatArgs = append(dnatArgs, "-m", "addrtype", "--dst-type", "LOCAL")
 	}
 	dnatArgs = append(dnatArgs, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort))
 
@@ -179,7 +189,7 @@ func AddPortMapping(hostInterface string, hostPort int, guestIP string, guestPor
 	// DNAT Rule (Local Host Traffic)
 	// We add this to the OUTPUT chain to allow the host to access its own published ports.
 	if hostInterface == "" || hostInterface == "0.0.0.0" || hostInterface == "127.0.0.1" {
-		outputArgs := []string{"-t", "nat", "-A", "OUTPUT", "-p", protocol, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
+		outputArgs := []string{"-t", "nat", "-A", "OUTPUT", "-p", protocol, "-m", "addrtype", "--dst-type", "LOCAL", "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
 		_ = runCmd("iptables", outputArgs...)
 	}
 
@@ -213,13 +223,15 @@ func RemovePortMapping(hostInterface string, hostPort int, guestIP string, guest
 		} else {
 			dnatArgs = append(dnatArgs, "-i", hostInterface)
 		}
+	} else {
+		dnatArgs = append(dnatArgs, "-m", "addrtype", "--dst-type", "LOCAL")
 	}
 	dnatArgs = append(dnatArgs, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort))
 	_ = runCmd("iptables", dnatArgs...)
 
 	// Remove OUTPUT chain rule if applicable
 	if hostInterface == "" || hostInterface == "0.0.0.0" || hostInterface == "127.0.0.1" {
-		outputArgs := []string{"-t", "nat", "-D", "OUTPUT", "-p", protocol, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
+		outputArgs := []string{"-t", "nat", "-D", "OUTPUT", "-p", protocol, "-m", "addrtype", "--dst-type", "LOCAL", "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
 		_ = runCmd("iptables", outputArgs...)
 	}
 

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"os/exec"
+	"strconv"
 
 	"github.com/vishvananda/netlink"
 )
@@ -152,6 +153,80 @@ func CreatePointToPointTap(name, hostIP, guestIP string, uid, gid int) error {
 	}
 
 	return nil
+}
+
+// AddPortMapping adds DNAT and FORWARD rules for a port mapping.
+func AddPortMapping(hostInterface string, hostPort int, guestIP string, guestPort int, protocol string) error {
+	if protocol == "" {
+		protocol = "tcp"
+	}
+
+	// DNAT Rule
+	dnatArgs := []string{"-t", "nat", "-A", "PREROUTING", "-p", protocol}
+	if hostInterface != "" && hostInterface != "0.0.0.0" {
+		if net.ParseIP(hostInterface) != nil {
+			dnatArgs = append(dnatArgs, "-d", hostInterface)
+		} else {
+			dnatArgs = append(dnatArgs, "-i", hostInterface)
+		}
+	}
+	dnatArgs = append(dnatArgs, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort))
+
+	if err := runCmd("iptables", dnatArgs...); err != nil {
+		return fmt.Errorf("iptables dnat add: %w", err)
+	}
+
+	// FORWARD Rule
+	fwdArgs := []string{"-A", "FORWARD", "-p", protocol, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
+	if err := runCmd("iptables", fwdArgs...); err != nil {
+		// Rollback DNAT rule
+		dnatArgs[3] = "-D" // Change -A to -D
+		_ = runCmd("iptables", dnatArgs...)
+		return fmt.Errorf("iptables forward add: %w", err)
+	}
+
+	slog.Info("port mapping added", "host", hostInterface, "hPort", hostPort, "gIP", guestIP, "gPort", guestPort)
+	return nil
+}
+
+// RemovePortMapping removes the DNAT and FORWARD rules for a port mapping.
+func RemovePortMapping(hostInterface string, hostPort int, guestIP string, guestPort int, protocol string) error {
+	if protocol == "" {
+		protocol = "tcp"
+	}
+
+	dnatArgs := []string{"-t", "nat", "-D", "PREROUTING", "-p", protocol}
+	if hostInterface != "" && hostInterface != "0.0.0.0" {
+		if net.ParseIP(hostInterface) != nil {
+			dnatArgs = append(dnatArgs, "-d", hostInterface)
+		} else {
+			dnatArgs = append(dnatArgs, "-i", hostInterface)
+		}
+	}
+	dnatArgs = append(dnatArgs, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort))
+	_ = runCmd("iptables", dnatArgs...)
+
+	fwdArgs := []string{"-D", "FORWARD", "-p", protocol, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
+	_ = runCmd("iptables", fwdArgs...)
+
+	slog.Info("port mapping removed", "host", hostInterface, "hPort", hostPort, "gIP", guestIP, "gPort", guestPort)
+	return nil
+}
+
+// FindAvailablePort find a random available port on the host.
+func FindAvailablePort(hostInterface string) (int, error) {
+	addr := "0.0.0.0:0"
+	if hostInterface != "" && hostInterface != "0.0.0.0" && net.ParseIP(hostInterface) != nil {
+		addr = hostInterface + ":0"
+	}
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return 0, fmt.Errorf("find available port: %w", err)
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // DeleteTap removes a TAP interface.

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -200,14 +200,19 @@ func AddPortMapping(hostInterface string, hostPort int, guestIP string, guestPor
 	}
 
 	// FORWARD Rule
-	fwdArgs := []string{"-A", "FORWARD", "-p", protocol, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
+	// Scoped: only allow traffic NOT originating from our own MicroVM subnet,
+	// so intra-subnet traffic is still subject to the RFC 1918 isolation DROP rules.
+	fwdArgs := []string{"-A", "FORWARD", "-p", protocol, "!", "-s", Subnet, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
 	if err := runCmd("iptables", fwdArgs...); err != nil {
 		// Rollback DNAT rules
-		dnatArgs[3] = "-D"
-		_ = runCmd("iptables", dnatArgs...)
-		
-		outputArgs := []string{"-t", "nat", "-D", "OUTPUT", "-p", protocol, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
-		_ = runCmd("iptables", outputArgs...)
+		// dnatArgs[2] is "-A" — mutate it to "-D" to delete the rule
+		rollbackArgs := make([]string, len(dnatArgs))
+		copy(rollbackArgs, dnatArgs)
+		rollbackArgs[2] = "-D"
+		_ = runCmd("iptables", rollbackArgs...)
+
+		outputRollbackArgs := []string{"-t", "nat", "-D", "OUTPUT", "-p", protocol, "-m", "addrtype", "--dst-type", "LOCAL", "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
+		_ = runCmd("iptables", outputRollbackArgs...)
 
 		return fmt.Errorf("iptables forward add: %w", err)
 	}

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -176,12 +176,23 @@ func AddPortMapping(hostInterface string, hostPort int, guestIP string, guestPor
 		return fmt.Errorf("iptables dnat add: %w", err)
 	}
 
+	// DNAT Rule (Local Host Traffic)
+	// We add this to the OUTPUT chain to allow the host to access its own published ports.
+	if hostInterface == "" || hostInterface == "0.0.0.0" || hostInterface == "127.0.0.1" {
+		outputArgs := []string{"-t", "nat", "-A", "OUTPUT", "-p", protocol, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
+		_ = runCmd("iptables", outputArgs...)
+	}
+
 	// FORWARD Rule
 	fwdArgs := []string{"-A", "FORWARD", "-p", protocol, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
 	if err := runCmd("iptables", fwdArgs...); err != nil {
-		// Rollback DNAT rule
-		dnatArgs[3] = "-D" // Change -A to -D
+		// Rollback DNAT rules
+		dnatArgs[3] = "-D"
 		_ = runCmd("iptables", dnatArgs...)
+		
+		outputArgs := []string{"-t", "nat", "-D", "OUTPUT", "-p", protocol, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
+		_ = runCmd("iptables", outputArgs...)
+
 		return fmt.Errorf("iptables forward add: %w", err)
 	}
 
@@ -206,6 +217,12 @@ func RemovePortMapping(hostInterface string, hostPort int, guestIP string, guest
 	dnatArgs = append(dnatArgs, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort))
 	_ = runCmd("iptables", dnatArgs...)
 
+	// Remove OUTPUT chain rule if applicable
+	if hostInterface == "" || hostInterface == "0.0.0.0" || hostInterface == "127.0.0.1" {
+		outputArgs := []string{"-t", "nat", "-D", "OUTPUT", "-p", protocol, "--dport", strconv.Itoa(hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", guestIP, guestPort)}
+		_ = runCmd("iptables", outputArgs...)
+	}
+
 	fwdArgs := []string{"-D", "FORWARD", "-p", protocol, "-d", guestIP, "--dport", strconv.Itoa(guestPort), "-j", "ACCEPT"}
 	_ = runCmd("iptables", fwdArgs...)
 
@@ -213,21 +230,6 @@ func RemovePortMapping(hostInterface string, hostPort int, guestIP string, guest
 	return nil
 }
 
-// FindAvailablePort find a random available port on the host.
-func FindAvailablePort(hostInterface string) (int, error) {
-	addr := "0.0.0.0:0"
-	if hostInterface != "" && hostInterface != "0.0.0.0" && net.ParseIP(hostInterface) != nil {
-		addr = hostInterface + ":0"
-	}
-
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		return 0, fmt.Errorf("find available port: %w", err)
-	}
-	defer l.Close()
-
-	return l.Addr().(*net.TCPAddr).Port, nil
-}
 
 // DeleteTap removes a TAP interface.
 func DeleteTap(name string) error {

--- a/internal/network/portmgr.go
+++ b/internal/network/portmgr.go
@@ -27,7 +27,7 @@ func NewPortManager(start, end int) *PortManager {
 // Allocate attempts to reserve a port for a specific VM.
 // If requestedPort is 0, it picks an available port from the ephemeral pool.
 // If requestedPort is > 0, it checks if the port is available and claims it.
-func (pm *PortManager) Allocate(requestedPort int, protocol string, vmID string) (int, error) {
+func (pm *PortManager) Allocate(requestedPort int, protocol string, iface string, vmID string) (int, error) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
@@ -35,8 +35,8 @@ func (pm *PortManager) Allocate(requestedPort int, protocol string, vmID string)
 		// Find first available in ephemeral range
 		for p := pm.ephemeralStart; p <= pm.ephemeralEnd; p++ {
 			if _, exists := pm.inUse[p]; !exists {
-				// Also check if host actually allows binding
-				if pm.isHostPortFree(protocol, p) {
+				// Also check if host actually allows binding (ephemeral: any interface)
+				if pm.isHostPortFree(protocol, p, "") {
 					pm.inUse[p] = vmID
 					return p, nil
 				}
@@ -53,8 +53,8 @@ func (pm *PortManager) Allocate(requestedPort int, protocol string, vmID string)
 		return 0, fmt.Errorf("port %d already in use by VM %s within herd", requestedPort, owner)
 	}
 
-	// Check if something else on the host is using it
-	if !pm.isHostPortFree(protocol, requestedPort) {
+	// Check if something else on the host is using it (on the specific interface)
+	if !pm.isHostPortFree(protocol, requestedPort, iface) {
 		return 0, fmt.Errorf("port %d is already in use by another process on the host", requestedPort)
 	}
 
@@ -62,8 +62,13 @@ func (pm *PortManager) Allocate(requestedPort int, protocol string, vmID string)
 	return requestedPort, nil
 }
 
-func (pm *PortManager) isHostPortFree(protocol string, port int) bool {
-	addr := fmt.Sprintf("0.0.0.0:%d", port)
+func (pm *PortManager) isHostPortFree(protocol string, port int, iface string) bool {
+	// Use the specific interface if provided, otherwise check all interfaces.
+	host := "0.0.0.0"
+	if iface != "" && iface != "0.0.0.0" {
+		host = iface
+	}
+	addr := fmt.Sprintf("%s:%d", host, port)
 	if protocol == "udp" {
 		l, err := net.ListenPacket("udp", addr)
 		if err != nil {

--- a/internal/network/portmgr.go
+++ b/internal/network/portmgr.go
@@ -1,0 +1,88 @@
+package network
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+// PortManager tracks host port usage across all MicroVMs managed by the daemon.
+// It supports both explicit "deterministic" allocation and random "ephemeral" allocation.
+type PortManager struct {
+	mu             sync.Mutex
+	inUse          map[int]string // port -> vmID
+	ephemeralStart int
+	ephemeralEnd   int
+}
+
+// NewPortManager initializes a new PortManager with the specified ephemeral range.
+func NewPortManager(start, end int) *PortManager {
+	return &PortManager{
+		inUse:          make(map[int]string),
+		ephemeralStart: start,
+		ephemeralEnd:   end,
+	}
+}
+
+// Allocate attempts to reserve a port for a specific VM.
+// If requestedPort is 0, it picks an available port from the ephemeral pool.
+// If requestedPort is > 0, it checks if the port is available and claims it.
+func (pm *PortManager) Allocate(requestedPort int, protocol string, vmID string) (int, error) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if requestedPort == 0 {
+		// Find first available in ephemeral range
+		for p := pm.ephemeralStart; p <= pm.ephemeralEnd; p++ {
+			if _, exists := pm.inUse[p]; !exists {
+				// Also check if host actually allows binding
+				if pm.isHostPortFree(protocol, p) {
+					pm.inUse[p] = vmID
+					return p, nil
+				}
+			}
+		}
+		return 0, fmt.Errorf("no ephemeral ports available in range %d-%d", pm.ephemeralStart, pm.ephemeralEnd)
+	}
+
+	// Explicit request
+	if owner, exists := pm.inUse[requestedPort]; exists {
+		if owner == vmID {
+			return requestedPort, nil // Already owned by this VM
+		}
+		return 0, fmt.Errorf("port %d already in use by VM %s within herd", requestedPort, owner)
+	}
+
+	// Check if something else on the host is using it
+	if !pm.isHostPortFree(protocol, requestedPort) {
+		return 0, fmt.Errorf("port %d is already in use by another process on the host", requestedPort)
+	}
+
+	pm.inUse[requestedPort] = vmID
+	return requestedPort, nil
+}
+
+func (pm *PortManager) isHostPortFree(protocol string, port int) bool {
+	addr := fmt.Sprintf("0.0.0.0:%d", port)
+	if protocol == "udp" {
+		l, err := net.ListenPacket("udp", addr)
+		if err != nil {
+			return false
+		}
+		l.Close()
+	} else {
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			return false
+		}
+		l.Close()
+	}
+	return true
+}
+
+// Release frees a previously allocated port.
+func (pm *PortManager) Release(port int) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	delete(pm.inUse, port)
+}

--- a/worker.go
+++ b/worker.go
@@ -55,6 +55,14 @@ type Worker[C any] interface {
 	io.Closer
 }
 
+// PortMapping describes a host-to-guest port forward.
+type PortMapping struct {
+	HostInterface string `json:"host_interface"` // e.g. "eth0", "192.168.0.1", or "0.0.0.0"
+	HostPort      int    `json:"host_port"`      // 0 means assign a random available port
+	GuestPort     int    `json:"guest_port"`
+	Protocol      string `json:"protocol"` // "tcp" or "udp"
+}
+
 // TenantConfig describes the on-demand container workload and its per-session limits.
 type TenantConfig struct {
 	Image              string
@@ -63,6 +71,7 @@ type TenantConfig struct {
 	IdleTimeoutSeconds int
 	TTLSeconds         int
 	HealthInterval     string
+	PortMappings       []PortMapping
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces support for publishing ports from host to guest VMs, including port mapping management, validation, and dynamic iptables rules for NAT. It adds new command-line options, configuration parameters, and integrates port mapping into the VM lifecycle, ensuring that ports are properly allocated, mapped, and released. The changes also improve network isolation and host-to-VM connectivity.

**Port Mapping and Publishing Support**

* Added a `--publish`/`-p` flag to the `herd deploy` command, allowing users to specify port mappings (e.g., `8080:80`, `:80`, `1.2.3.4:8080:80`) that are parsed and included in session creation requests (`cmd/herd/deploy.go`). [[1]](diffhunk://#diff-f05debcfd01afb88c2908d90b82cf7c8d3bb8f7b157cd2b91d8c4632574589dfR56-R100) [[2]](diffhunk://#diff-f05debcfd01afb88c2908d90b82cf7c8d3bb8f7b157cd2b91d8c4632574589dfR137)
* Extended the API and session handling to accept and respond with port mapping information, ensuring that dynamically assigned ports are communicated back to the client (`internal/daemon/api.go`). [[1]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fR148-R156) [[2]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fR187) [[3]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fR212-R217)

**Port Manager Integration**

* Introduced `EphemeralPortStart` and `EphemeralPortEnd` configuration options, with validation and sensible defaults, to control the range of host ports available for dynamic allocation (`internal/config/config.go`, `cmd/herd/init.go`). [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR79-R80) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR126-R131) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR147-R155) [[4]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18R247-R248)
* Integrated a `PortManager` into the VM factory and worker lifecycle, ensuring ports are allocated on spawn and released on VM close (`firecracker_factory.go`, `cmd/herd/start.go`). [[1]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR40) [[2]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR76-R77) [[3]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR170-R176) [[4]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR508-R532) [[5]](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eR548-R549) [[6]](diffhunk://#diff-4cf15602fb33e8ebbd1b0c8d5c717d727360ab025c5b527bb64207d3240acd40R195-R196) [[7]](diffhunk://#diff-4cf15602fb33e8ebbd1b0c8d5c717d727360ab025c5b527bb64207d3240acd40R205)

**iptables/NAT Rule Management**

* Implemented `AddPortMapping` and `RemovePortMapping` functions to add and remove DNAT and FORWARD iptables rules for each published port, including handling for localhost and hairpin NAT, and robust error handling/rollback (`internal/network/nat.go`).
* Enhanced NAT setup and teardown to support host-to-VM connectivity and isolation, including rules for loopback and hairpin traffic (`internal/network/nat.go`). [[1]](diffhunk://#diff-32b32ff86499a9e297c08cde4d0605cb7dd163e03ab997af9332361d02621718R32-R50) [[2]](diffhunk://#diff-32b32ff86499a9e297c08cde4d0605cb7dd163e03ab997af9332361d02621718R77)

**Cloud Client and Future Work**

* Added a TODO in the cloud client for future support of port mappings in VM boot commands, outlining the expected integration path (`internal/cloud/client.go`).