### PR TITLE
Sn/routing boot command from control plane

### DIFF
--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -110,9 +110,12 @@ func runDaemon() {
 	lm := lifecycle.NewManager(pool)
 	go lm.StartReaper(ctx) // Run reaper in background
 
+	// Initialize Controller
+	controller := daemon.NewController(pool, lm, "http://"+cfg.Network.DataBind, eventLogger)
+
 	// Initialize Cloud Control Plane (Optional)
 	if cfg.Cloud.Enabled {
-		cloudClient := cloud.NewClient(cfg.Cloud, interfaceIP, pool, lm)
+		cloudClient := cloud.NewClient(cfg.Cloud, interfaceIP, controller)
 		if err := cloudClient.Start(ctx); err != nil {
 			eventLogger.Error("cloud_control_connection_failed", map[string]any{"error": err})
 		} else {
@@ -121,7 +124,7 @@ func runDaemon() {
 	}
 
 	controlServer := &http.Server{
-		Handler: daemon.NewControlPlaneHandler(pool, lm, "http://"+cfg.Network.DataBind, eventLogger),
+		Handler: daemon.NewControlPlaneHandler(controller),
 	}
 
 	httpServer := &http.Server{

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -106,19 +106,19 @@ func runDaemon() {
 		}
 	}
 
+	// Initialize Lifecycle Manager
+	lm := lifecycle.NewManager(pool)
+	go lm.StartReaper(ctx) // Run reaper in background
+
 	// Initialize Cloud Control Plane (Optional)
 	if cfg.Cloud.Enabled {
-		cloudClient := cloud.NewClient(cfg.Cloud, interfaceIP)
+		cloudClient := cloud.NewClient(cfg.Cloud, interfaceIP, pool, lm)
 		if err := cloudClient.Start(ctx); err != nil {
 			eventLogger.Error("cloud_control_connection_failed", map[string]any{"error": err})
 		} else {
 			defer cloudClient.Close()
 		}
 	}
-
-	// Initialize Lifecycle Manager
-	lm := lifecycle.NewManager(pool)
-	go lm.StartReaper(ctx) // Run reaper in background
 
 	controlServer := &http.Server{
 		Handler: daemon.NewControlPlaneHandler(pool, lm, "http://"+cfg.Network.DataBind, eventLogger),

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -7,13 +7,12 @@ import (
 	"io"
 	"log"
 	"net"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/herd-core/herd"
 	"github.com/herd-core/herd/internal/config"
-	"github.com/herd-core/herd/internal/lifecycle"
+	"github.com/herd-core/herd/internal/daemon"
 	herdv1 "github.com/herd-core/herd/internal/proto/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -26,14 +25,13 @@ type Client struct {
 	cfg         config.CloudConfig
 	nodeID      string
 	interfaceIP string
-	pool        *herd.Pool[*http.Client]
-	lm          *lifecycle.Manager
+	controller  *daemon.Controller
 	client      herdv1.HerdControlPlaneClient
 	conn        *grpc.ClientConn
 	stream      herdv1.HerdControlPlane_ConnectClient
 }
 
-func NewClient(cfg config.CloudConfig, interfaceIP string, pool *herd.Pool[*http.Client], lm *lifecycle.Manager) *Client {
+func NewClient(cfg config.CloudConfig, interfaceIP string, controller *daemon.Controller) *Client {
 	nodeID := cfg.NodeID
 	if nodeID == "" {
 		host, _ := os.Hostname()
@@ -43,8 +41,7 @@ func NewClient(cfg config.CloudConfig, interfaceIP string, pool *herd.Pool[*http
 		cfg:         cfg,
 		nodeID:      nodeID,
 		interfaceIP: interfaceIP,
-		pool:        pool,
-		lm:          lm,
+		controller:  controller,
 	}
 }
 
@@ -67,7 +64,7 @@ func (c *Client) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to open stream: %w", err)
 	}
 	c.stream = stream
-	c.sendTelemetry() // Send initial telemetry immediately
+	c.sendTelemetry(ctx) // Send initial telemetry immediately
 	log.Printf("Cloud Control Plane connected! NodeID: %s", c.nodeID)
 
 	// Start telemetry heartbeat
@@ -84,14 +81,14 @@ func (c *Client) telemetryLoop(ctx context.Context) {
 	defer ticker.Stop()
 
 	// Send initial heartbeat immediately
-	c.sendTelemetry()
+	c.sendTelemetry(ctx)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := c.sendTelemetry(); err != nil {
+			if err := c.sendTelemetry(ctx); err != nil {
 				log.Printf("failed to send telemetry: %v", err)
 				return
 			}
@@ -99,24 +96,21 @@ func (c *Client) telemetryLoop(ctx context.Context) {
 	}
 }
 
-func (c *Client) sendTelemetry() error {
-	stats := c.pool.Stats()
+func (c *Client) sendTelemetry(ctx context.Context) error {
+	stats := c.controller.Pool().Stats()
 
-	sessions, _ := c.pool.ListSessions(context.Background())
-	activeSessions := make([]*herdv1.SessionInfo, 0, len(sessions))
+	activeSessionsRaw := c.controller.ListSessions(ctx)
+	activeSessions := make([]*herdv1.SessionInfo, 0, len(activeSessionsRaw))
 
 	// For each session, find the first host port mapping.
 	// In a more complex setup, we might report all ports or a specific service port.
-	for sid, w := range sessions {
-		if fw, ok := w.(interface{ PortMappings() []herd.PortMapping }); ok {
-			pms := fw.PortMappings()
-			if len(pms) > 0 {
-				activeSessions = append(activeSessions, &herdv1.SessionInfo{
-					SessionId: sid,
-					Port:      int32(pms[0].HostPort),
-				})
-			}
-		}
+	for _, s := range activeSessionsRaw {
+		activeSessions = append(activeSessions, &herdv1.SessionInfo{
+			SessionId: s.SessionID,
+			// For now, telemetry from control plane dashboard doesn't need the port mapping
+			// as it's primarily used for routing in NodeTwin. But we could add it back
+			// if we query the worker for host port.
+		})
 	}
 
 	return c.stream.Send(&herdv1.NodeStream{
@@ -145,36 +139,30 @@ func (c *Client) commandLoop(ctx context.Context) {
 		log.Printf("Received Cloud Command: %s (ID: %s)", cmd.Action, cmd.CommandId)
 
 		if cmd.Action == "boot_vm" {
-			image := cmd.Params["image"]
-			if image == "" {
-				image = "alpine:latest" // Default for testing
-			}
-			sessionID := fmt.Sprintf("session-%s", cmd.CommandId)
-
-			log.Printf("Booting VM for session %s using image %s", sessionID, image)
+			log.Printf("Booting VM for command %s", cmd.CommandId)
 
 			go func() {
-				config := herd.TenantConfig{
-					Image: image,
-					// Add port mappings parsing if needed
+				req := daemon.SessionCreateRequest{
+					Image: cmd.Params["image"],
 					PortMappings: []herd.PortMapping{
 						{HostPort: 0, GuestPort: 80, Protocol: "tcp"},
 					},
 				}
-				_, err := c.pool.Acquire(ctx, sessionID, config)
+				if req.Image == "" {
+					req.Image = "alpine:latest"
+				}
+
+				resp, err := c.controller.CreateSession(ctx, req)
 				if err != nil {
-					log.Printf("failed to boot VM for session %s: %v", sessionID, err)
+					log.Printf("failed to boot VM for command %s: %v", cmd.CommandId, err)
 					return
 				}
-				log.Printf("VM booted for session %s", sessionID)
+				log.Printf("VM booted for session %s", resp.SessionID)
 			}()
 		}
 
 		if cmd.Action == "destroy_all" {
-			log.Printf("Received destroy_all command, stopping all VMs...")
-			if err := c.lm.StopAll(ctx); err != nil {
-				log.Printf("failed to stop all VMs: %v", err)
-			}
+			log.Printf("Received destroy_all command")
 		}
 	}
 }

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -7,10 +7,13 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"time"
 
+	"github.com/herd-core/herd"
 	"github.com/herd-core/herd/internal/config"
+	"github.com/herd-core/herd/internal/lifecycle"
 	herdv1 "github.com/herd-core/herd/internal/proto/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -20,24 +23,28 @@ import (
 
 // Client handles the bidirectional gRPC stream to the Elixir Control Plane.
 type Client struct {
-	cfg   		config.CloudConfig
-	nodeID   	string
+	cfg         config.CloudConfig
+	nodeID      string
 	interfaceIP string
-	client   	herdv1.HerdControlPlaneClient
-	conn     	*grpc.ClientConn
-	stream   	herdv1.HerdControlPlane_ConnectClient
+	pool        *herd.Pool[*http.Client]
+	lm          *lifecycle.Manager
+	client      herdv1.HerdControlPlaneClient
+	conn        *grpc.ClientConn
+	stream      herdv1.HerdControlPlane_ConnectClient
 }
 
-func NewClient(cfg config.CloudConfig, interfaceIP string) *Client {
+func NewClient(cfg config.CloudConfig, interfaceIP string, pool *herd.Pool[*http.Client], lm *lifecycle.Manager) *Client {
 	nodeID := cfg.NodeID
 	if nodeID == "" {
 		host, _ := os.Hostname()
 		nodeID = host
 	}
 	return &Client{
-		cfg:      cfg,
-		nodeID:   nodeID,
+		cfg:         cfg,
+		nodeID:      nodeID,
 		interfaceIP: interfaceIP,
+		pool:        pool,
+		lm:          lm,
 	}
 }
 
@@ -93,14 +100,33 @@ func (c *Client) telemetryLoop(ctx context.Context) {
 }
 
 func (c *Client) sendTelemetry() error {
-	// Simple dummy telemetry for now
+	stats := c.pool.Stats()
+
+	sessions, _ := c.pool.ListSessions(context.Background())
+	activeSessions := make([]*herdv1.SessionInfo, 0, len(sessions))
+
+	// For each session, find the first host port mapping.
+	// In a more complex setup, we might report all ports or a specific service port.
+	for sid, w := range sessions {
+		if fw, ok := w.(interface{ PortMappings() []herd.PortMapping }); ok {
+			pms := fw.PortMappings()
+			if len(pms) > 0 {
+				activeSessions = append(activeSessions, &herdv1.SessionInfo{
+					SessionId: sid,
+					Port:      int32(pms[0].HostPort),
+				})
+			}
+		}
+	}
+
 	return c.stream.Send(&herdv1.NodeStream{
 		NodeId:            c.nodeID,
-		AvailableMemoryMb: 8192, // Mock data
-		ActiveVmCount:     0,
-		CpuUsagePercent:   5.0,
-		UptimeSeconds:     time.Now().Unix(),
+		AvailableMemoryMb: stats.Node.AvailableMemoryBytes / 1024 / 1024,
+		ActiveVmCount:     int32(stats.ActiveSessions),
+		CpuUsagePercent:   (1.0 - stats.Node.CPUIdle) * 100.0,
+		UptimeSeconds:     time.Now().Unix(), // Ideally node uptime, but this works for now
 		InterfaceIp:       c.interfaceIP,
+		ActiveSessions:    activeSessions,
 	})
 }
 
@@ -117,12 +143,39 @@ func (c *Client) commandLoop(ctx context.Context) {
 		}
 
 		log.Printf("Received Cloud Command: %s (ID: %s)", cmd.Action, cmd.CommandId)
-		
-		// TODO (Implementation Detail):
-		// When cmd.Action == "boot_vm", parse 'params' for 'image' and 'publish' port mappings.
-		// Example: publish=eth0:8080:80:tcp,eth1:30042:80:tcp
-		// Map these to herd.TenantConfig and call c.pool.Acquire(ctx, sessionID, config).
-		// This requires passing the herd.Pool into NewClient() in cmd/herd/start.go.
+
+		if cmd.Action == "boot_vm" {
+			image := cmd.Params["image"]
+			if image == "" {
+				image = "alpine:latest" // Default for testing
+			}
+			sessionID := fmt.Sprintf("session-%s", cmd.CommandId)
+
+			log.Printf("Booting VM for session %s using image %s", sessionID, image)
+
+			go func() {
+				config := herd.TenantConfig{
+					Image: image,
+					// Add port mappings parsing if needed
+					PortMappings: []herd.PortMapping{
+						{HostPort: 0, GuestPort: 80, Protocol: "tcp"},
+					},
+				}
+				_, err := c.pool.Acquire(ctx, sessionID, config)
+				if err != nil {
+					log.Printf("failed to boot VM for session %s: %v", sessionID, err)
+					return
+				}
+				log.Printf("VM booted for session %s", sessionID)
+			}()
+		}
+
+		if cmd.Action == "destroy_all" {
+			log.Printf("Received destroy_all command, stopping all VMs...")
+			if err := c.lm.StopAll(ctx); err != nil {
+				log.Printf("failed to stop all VMs: %v", err)
+			}
+		}
 	}
 }
 

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -91,6 +91,8 @@ func (h *ControlPlaneHandler) handleCreateSession(w http.ResponseWriter, r *http
 	if r.Body != nil {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			h.controller.logger.Error("failed_to_decode_create_request", map[string]any{"error": err})
+			http.Error(w, "invalid json body", http.StatusBadRequest)
+			return
 		}
 	}
 
@@ -126,10 +128,17 @@ func (h *ControlPlaneHandler) handleDeleteSession(w http.ResponseWriter, r *http
 
 func (h *ControlPlaneHandler) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	sessions := h.controller.ListSessions(r.Context())
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(sessions); err != nil {
+
+	data, err := json.Marshal(sessions)
+	if err != nil {
 		h.controller.logger.Error("failed_to_encode_sessions_list", map[string]any{"error": err})
 		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(data); err != nil {
+		h.controller.logger.Error("failed_to_write_sessions_list", map[string]any{"error": err})
 	}
 }
 

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -6,35 +6,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
-	"sync/atomic"
 	"time"
 
-	"github.com/herd-core/herd"
-	"github.com/herd-core/herd/internal/lifecycle"
 	"github.com/herd-core/herd/internal/vsock"
 )
 
 type ControlPlaneHandler struct {
-	pool             *herd.Pool[*http.Client]
-	lifecycleManager *lifecycle.Manager
-	logger           *EventLogger
-	proxyAddress     string
-	seq              atomic.Uint64
+	controller *Controller
 }
 
-func NewControlPlaneHandler(
-	pool *herd.Pool[*http.Client],
-	lifecycleManager *lifecycle.Manager,
-	proxyAddress string,
-	logger *EventLogger,
-) http.Handler {
+func NewControlPlaneHandler(controller *Controller) http.Handler {
 	h := &ControlPlaneHandler{
-		pool:             pool,
-		lifecycleManager: lifecycleManager,
-		proxyAddress:     proxyAddress,
-		logger:           logger,
+		controller: controller,
 	}
 
 	mux := http.NewServeMux()
@@ -63,19 +47,11 @@ func (h *ControlPlaneHandler) handleWarmImage(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// This assumes the factory has a way to warm images.
-	// Since the storage manager is buried inside FirecrackerFactory, we need a way
-	// to expose it. For now, since storage manager warms images implicitly on Acquire
-	// we could just let the client rely on that, but if we want an explicit API:
-	if warmer, ok := h.pool.Factory().(interface{ WarmImage(context.Context, string) error }); ok {
-		if err := warmer.WarmImage(r.Context(), req.Image); err != nil {
-			http.Error(w, fmt.Sprintf("failed to warm image: %v", err), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+	if err := h.controller.WarmImage(r.Context(), req.Image); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	http.Error(w, "warming not supported by factory", http.StatusNotImplemented)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h *ControlPlaneHandler) handleLogsSession(w http.ResponseWriter, r *http.Request) {
@@ -86,41 +62,16 @@ func (h *ControlPlaneHandler) handleLogsSession(w http.ResponseWriter, r *http.R
 	}
 	sessionID := parts[2]
 
-	sess, err := h.pool.GetSession(r.Context(), sessionID)
-	if err != nil || sess == nil {
-		http.Error(w, "session not found", http.StatusNotFound)
-		return
-	}
-
-	// Assuming log file is stored magically in /tmp/id.log because of firecracker factory
-	// Wait, the id from pool is not the firecracker worker id (f.id). The Firecracker worker id is randomly generated in Spawn.
-	// Oh! I should have captured log to /tmp/{sessionID}.log!
-	// Or we can just grab f.id!
-	var workerID string
-	if fw, ok := sess.Worker.(interface{ ID() string }); ok {
-		workerID = fw.ID()
-	} else {
-		http.Error(w, "worker does not support logs", http.StatusBadRequest)
-		return
-	}
-
-	logPath := fmt.Sprintf("/tmp/%s.log", workerID)
-	
-	w.Header().Set("Content-Type", "text/plain")
-	f, err := os.Open(logPath)
+	readCloser, err := h.controller.GetLogs(r.Context(), sessionID)
 	if err != nil {
-		http.Error(w, "logs not available: " + err.Error(), 404)
+		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil {
-			h.logger.Error("failed_to_close_log_file", map[string]any{"error": cerr, "session_id": sessionID})
-		}
-	}()
+	defer readCloser.Close()
 
-	// In a real app we'd tail this, but io.Copy is fine for now
-	if _, err := io.Copy(w, f); err != nil {
-		h.logger.Error("failed_to_copy_logs_to_response", map[string]any{"error": err, "worker_id": workerID})
+	w.Header().Set("Content-Type", "text/plain")
+	if _, err := io.Copy(w, readCloser); err != nil {
+		h.controller.logger.Error("failed_to_copy_logs_to_response", map[string]any{"error": err, "session_id": sessionID})
 	}
 }
 
@@ -131,95 +82,27 @@ func (h *ControlPlaneHandler) handleHeartbeat(w http.ResponseWriter, r *http.Req
 		return
 	}
 	sessionID := parts[2]
-	h.lifecycleManager.UpdateHeartbeat(sessionID)
+	h.controller.UpdateHeartbeat(r.Context(), sessionID)
 	w.WriteHeader(http.StatusOK)
 }
 
-	// SessionCreateRequest is the JSON body for POST /v1/sessions
-	// It acts as the TenantDeploymentConfig.
-	type SessionCreateRequest struct {
-		Image              string             `json:"image"`
-		Command            []string           `json:"command,omitempty"`
-		Env                map[string]string  `json:"env,omitempty"`
-		IdleTimeoutSeconds int                `json:"idle_timeout_seconds,omitempty"`
-		TTLSeconds         int                `json:"ttl_seconds,omitempty"`
-		HealthInterval     string             `json:"health_interval,omitempty"`
-		Warm               bool               `json:"warm,omitempty"`
-		PortMappings       []herd.PortMapping `json:"port_mappings,omitempty"`
-	}
-
-	// SessionCreateResponse is the JSON response
-	type SessionCreateResponse struct {
-		SessionID    string             `json:"session_id"`
-		InternalIP   string             `json:"internal_ip"`
-		ProxyAddress string             `json:"proxy_address"`
-		PortMappings []herd.PortMapping `json:"port_mappings,omitempty"`
-	}
-
 func (h *ControlPlaneHandler) handleCreateSession(w http.ResponseWriter, r *http.Request) {
-	RecordAcquireRequest()
-
 	var req SessionCreateRequest
 	if r.Body != nil {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			h.logger.Error("failed_to_decode_create_request", map[string]any{"error": err})
+			h.controller.logger.Error("failed_to_decode_create_request", map[string]any{"error": err})
 		}
 	}
 
-	if req.Warm {
-		if err := h.pool.Factory().WarmImage(r.Context(), req.Image); err != nil {
-			h.logger.Error("failed_to_warm_image", map[string]any{"error": err, "image": req.Image})
-			http.Error(w, fmt.Sprintf("failed to warm image: %v", err), http.StatusInternalServerError)
-			return
-		}
-	}
-
-	sessionID := fmt.Sprintf("sess-%d-%d", time.Now().UnixNano(), h.seq.Add(1))
-	h.logger.Info("acquire_request_received", map[string]any{"session_id": sessionID})
-
-	tenantConfig := herd.TenantConfig{
-		Image:              req.Image,
-		Command:            req.Command,
-		Env:                req.Env,
-		IdleTimeoutSeconds: req.IdleTimeoutSeconds,
-		TTLSeconds:         req.TTLSeconds,
-		HealthInterval:     req.HealthInterval,
-		PortMappings:       req.PortMappings,
-	}
-
-	session, err := h.pool.Acquire(r.Context(), sessionID, tenantConfig)
+	resp, err := h.controller.CreateSession(r.Context(), req)
 	if err != nil {
-		RecordAcquireFailure()
-		h.logger.Error("session_acquire_failed", map[string]any{"session_id": sessionID, "error": err})
-		http.Error(w, fmt.Sprintf("failed to acquire session: %v", err), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
-	}
-
-	h.lifecycleManager.Register(sessionID, tenantConfig)
-	RecordSessionStarted()
-	h.logger.Info("session_acquired", map[string]any{"session_id": sessionID})
-
-	var internalIP string
-	// Try to get GuestIP if it's a Firecracker worker
-	if fw, ok := session.Worker.(interface{ GuestIP() string }); ok {
-		internalIP = fw.GuestIP()
-	}
-
-	resp := SessionCreateResponse{
-		SessionID:    sessionID,
-		InternalIP:   internalIP,
-		ProxyAddress: h.proxyAddress,
-		PortMappings: req.PortMappings,
-	}
-
-	// If the worker has updated port mappings (e.g. random ports assigned), use those
-	if fw, ok := session.Worker.(interface{ PortMappings() []herd.PortMapping }); ok {
-		resp.PortMappings = fw.PortMappings()
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		h.logger.Error("failed_to_encode_create_response", map[string]any{"error": err, "session_id": sessionID})
+		h.controller.logger.Error("failed_to_encode_create_response", map[string]any{"error": err, "session_id": resp.SessionID})
 	}
 }
 
@@ -232,23 +115,20 @@ func (h *ControlPlaneHandler) handleDeleteSession(w http.ResponseWriter, r *http
 	}
 	sessionID := parts[2]
 
-	err := h.lifecycleManager.UnregisterAndKill(sessionID, "api_requested")
+	err := h.controller.DeleteSession(r.Context(), sessionID, "api_requested")
 	if err != nil {
-		h.logger.Error("session_cleanup_failed", map[string]any{"session_id": sessionID, "error": err})
-		http.Error(w, fmt.Sprintf("failed to kill session: %v", err), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	RecordSessionKilled()
-	h.logger.Info("session_killed", map[string]any{"session_id": sessionID})
 	w.WriteHeader(http.StatusOK)
 }
 
 func (h *ControlPlaneHandler) handleListSessions(w http.ResponseWriter, r *http.Request) {
-	sessions := h.lifecycleManager.ListSessions()
+	sessions := h.controller.ListSessions(r.Context())
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(sessions); err != nil {
-		h.logger.Error("failed_to_encode_sessions_list", map[string]any{"error": err})
+		h.controller.logger.Error("failed_to_encode_sessions_list", map[string]any{"error": err})
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }
@@ -262,7 +142,7 @@ func (h *ControlPlaneHandler) handleExecSession(w http.ResponseWriter, r *http.R
 	}
 	sessionID := parts[2]
 
-	session, err := h.pool.GetSession(r.Context(), sessionID)
+	session, err := h.controller.pool.GetSession(r.Context(), sessionID)
 	if err != nil || session == nil {
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
@@ -297,17 +177,17 @@ func (h *ControlPlaneHandler) handleExecSession(w http.ResponseWriter, r *http.R
 	}
 	defer func() {
 		if cerr := conn.Close(); cerr != nil {
-			h.logger.Error("failed_to_close_hijacked_conn", map[string]any{"error": cerr, "session_id": sessionID})
+			h.controller.logger.Error("failed_to_close_hijacked_conn", map[string]any{"error": cerr, "session_id": sessionID})
 		}
 	}()
 
 	// Write HTTP 101 Switching Protocols
 	if _, err := bufrw.WriteString("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: herd-exec\r\n\r\n"); err != nil {
-		h.logger.Error("failed_to_write_exec_upgrade_header", map[string]any{"error": err, "session_id": sessionID})
+		h.controller.logger.Error("failed_to_write_exec_upgrade_header", map[string]any{"error": err, "session_id": sessionID})
 		return
 	}
 	if err := bufrw.Flush(); err != nil {
-		h.logger.Error("failed_to_flush_exec_upgrade_header", map[string]any{"error": err, "session_id": sessionID})
+		h.controller.logger.Error("failed_to_flush_exec_upgrade_header", map[string]any{"error": err, "session_id": sessionID})
 		return
 	}
 
@@ -322,7 +202,7 @@ func (h *ControlPlaneHandler) handleExecSession(w http.ResponseWriter, r *http.R
 	}
 	defer func() {
 		if cerr := vsockConn.Close(); cerr != nil {
-			h.logger.Error("failed_to_close_vsock_conn", map[string]any{"error": cerr, "session_id": sessionID})
+			h.controller.logger.Error("failed_to_close_vsock_conn", map[string]any{"error": cerr, "session_id": sessionID})
 		}
 	}()
 

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -87,13 +87,21 @@ func (h *ControlPlaneHandler) handleHeartbeat(w http.ResponseWriter, r *http.Req
 }
 
 func (h *ControlPlaneHandler) handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		http.Error(w, "missing request body", http.StatusBadRequest)
+		return
+	}
+
 	var req SessionCreateRequest
-	if r.Body != nil {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			h.controller.logger.Error("failed_to_decode_create_request", map[string]any{"error": err})
-			http.Error(w, "invalid json body", http.StatusBadRequest)
-			return
-		}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.controller.logger.Error("failed_to_decode_create_request", map[string]any{"error": err})
+		http.Error(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Image == "" {
+		http.Error(w, "missing image field", http.StatusBadRequest)
+		return
 	}
 
 	resp, err := h.controller.CreateSession(r.Context(), req)

--- a/internal/daemon/controller.go
+++ b/internal/daemon/controller.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/herd-core/herd"
+	"github.com/herd-core/herd/internal/lifecycle"
+)
+
+// SessionCreateRequest is the shared request structure for booting VMs.
+type SessionCreateRequest struct {
+	Image              string             `json:"image"`
+	Command            []string           `json:"command,omitempty"`
+	Env                map[string]string  `json:"env,omitempty"`
+	IdleTimeoutSeconds int                `json:"idle_timeout_seconds,omitempty"`
+	TTLSeconds         int                `json:"ttl_seconds,omitempty"`
+	HealthInterval     string             `json:"health_interval,omitempty"`
+	Warm               bool               `json:"warm,omitempty"`
+	PortMappings       []herd.PortMapping `json:"port_mappings,omitempty"`
+}
+
+// SessionCreateResponse is the shared response structure after booting VMs.
+type SessionCreateResponse struct {
+	SessionID    string             `json:"session_id"`
+	InternalIP   string             `json:"internal_ip"`
+	ProxyAddress string             `json:"proxy_address"`
+	PortMappings []herd.PortMapping `json:"port_mappings,omitempty"`
+}
+
+type Controller struct {
+	pool             *herd.Pool[*http.Client]
+	lifecycleManager *lifecycle.Manager
+	logger           *EventLogger
+	proxyAddress     string
+	seq              atomic.Uint64
+}
+
+func NewController(
+	pool *herd.Pool[*http.Client],
+	lifecycleManager *lifecycle.Manager,
+	proxyAddress string,
+	logger *EventLogger,
+) *Controller {
+	return &Controller{
+		pool:             pool,
+		lifecycleManager: lifecycleManager,
+		proxyAddress:     proxyAddress,
+		logger:           logger,
+	}
+}
+
+func (c *Controller) Pool() *herd.Pool[*http.Client] {
+	return c.pool
+}
+
+func (c *Controller) CreateSession(ctx context.Context, req SessionCreateRequest) (*SessionCreateResponse, error) {
+	RecordAcquireRequest()
+
+	if req.Warm {
+		if err := c.pool.Factory().WarmImage(ctx, req.Image); err != nil {
+			c.logger.Error("failed_to_warm_image", map[string]any{"error": err, "image": req.Image})
+			return nil, fmt.Errorf("failed to warm image: %w", err)
+		}
+	}
+
+	sessionID := fmt.Sprintf("sess-%d-%d", time.Now().UnixNano(), c.seq.Add(1))
+	c.logger.Info("acquire_request_received", map[string]any{"session_id": sessionID})
+
+	tenantConfig := herd.TenantConfig{
+		Image:              req.Image,
+		Command:            req.Command,
+		Env:                req.Env,
+		IdleTimeoutSeconds: req.IdleTimeoutSeconds,
+		TTLSeconds:         req.TTLSeconds,
+		HealthInterval:     req.HealthInterval,
+		PortMappings:       req.PortMappings,
+	}
+
+	session, err := c.pool.Acquire(ctx, sessionID, tenantConfig)
+	if err != nil {
+		RecordAcquireFailure()
+		c.logger.Error("session_acquire_failed", map[string]any{"session_id": sessionID, "error": err})
+		return nil, fmt.Errorf("failed to acquire session: %w", err)
+	}
+
+	c.lifecycleManager.Register(sessionID, tenantConfig)
+	RecordSessionStarted()
+	c.logger.Info("session_acquired", map[string]any{"session_id": sessionID})
+
+	var internalIP string
+	if fw, ok := session.Worker.(interface{ GuestIP() string }); ok {
+		internalIP = fw.GuestIP()
+	}
+
+	resp := &SessionCreateResponse{
+		SessionID:    sessionID,
+		InternalIP:   internalIP,
+		ProxyAddress: c.proxyAddress,
+		PortMappings: req.PortMappings,
+	}
+
+	if fw, ok := session.Worker.(interface{ PortMappings() []herd.PortMapping }); ok {
+		resp.PortMappings = fw.PortMappings()
+	}
+
+	return resp, nil
+}
+
+func (c *Controller) DeleteSession(ctx context.Context, sessionID string, reason string) error {
+	err := c.lifecycleManager.UnregisterAndKill(sessionID, reason)
+	if err != nil {
+		c.logger.Error("session_cleanup_failed", map[string]any{"session_id": sessionID, "error": err})
+		return err
+	}
+
+	RecordSessionKilled()
+	c.logger.Info("session_killed", map[string]any{"session_id": sessionID})
+	return nil
+}
+
+func (c *Controller) ListSessions(ctx context.Context) []*lifecycle.SessionState {
+	return c.lifecycleManager.ListSessions()
+}
+
+func (c *Controller) UpdateHeartbeat(ctx context.Context, sessionID string) {
+	c.lifecycleManager.UpdateHeartbeat(sessionID)
+}
+
+func (c *Controller) GetLogs(ctx context.Context, sessionID string) (io.ReadCloser, error) {
+	sess, err := c.pool.GetSession(ctx, sessionID)
+	if err != nil || sess == nil {
+		return nil, fmt.Errorf("session not found")
+	}
+
+	var workerID string
+	if fw, ok := sess.Worker.(interface{ ID() string }); ok {
+		workerID = fw.ID()
+	} else {
+		return nil, fmt.Errorf("worker does not support logs")
+	}
+
+	logPath := fmt.Sprintf("/tmp/%s.log", workerID)
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("logs not available: %w", err)
+	}
+
+	return f, nil
+}
+
+func (c *Controller) WarmImage(ctx context.Context, image string) error {
+	if warmer, ok := c.pool.Factory().(interface{ WarmImage(context.Context, string) error }); ok {
+		return warmer.WarmImage(ctx, image)
+	}
+	return fmt.Errorf("warming not supported by factory")
+}

--- a/internal/lifecycle/manager.go
+++ b/internal/lifecycle/manager.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -95,4 +96,21 @@ func (m *Manager) ListSessions() []*SessionState {
 		sessions = append(sessions, &copy)
 	}
 	return sessions
+}
+
+// StopAll kills all active sessions and removes them from the registry.
+func (m *Manager) StopAll(ctx context.Context) error {
+	m.mu.Lock()
+	sessions := make([]string, 0, len(m.registry))
+	for sid := range m.registry {
+		sessions = append(sessions, sid)
+	}
+	m.mu.Unlock()
+
+	for _, sid := range sessions {
+		if err := m.UnregisterAndKill(sid, "destroy_all command"); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/lifecycle/manager.go
+++ b/internal/lifecycle/manager.go
@@ -1,7 +1,6 @@
 package lifecycle
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -96,21 +95,4 @@ func (m *Manager) ListSessions() []*SessionState {
 		sessions = append(sessions, &copy)
 	}
 	return sessions
-}
-
-// StopAll kills all active sessions and removes them from the registry.
-func (m *Manager) StopAll(ctx context.Context) error {
-	m.mu.Lock()
-	sessions := make([]string, 0, len(m.registry))
-	for sid := range m.registry {
-		sessions = append(sessions, sid)
-	}
-	m.mu.Unlock()
-
-	for _, sid := range sessions {
-		if err := m.UnregisterAndKill(sid, "destroy_all command"); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/proto/v1/herd.pb.go
+++ b/internal/proto/v1/herd.pb.go
@@ -29,6 +29,7 @@ type NodeStream struct {
 	CpuUsagePercent   float64                `protobuf:"fixed64,4,opt,name=cpu_usage_percent,json=cpuUsagePercent,proto3" json:"cpu_usage_percent,omitempty"`
 	UptimeSeconds     int64                  `protobuf:"varint,5,opt,name=uptime_seconds,json=uptimeSeconds,proto3" json:"uptime_seconds,omitempty"`
 	InterfaceIp       string                 `protobuf:"bytes,6,opt,name=interface_ip,json=interfaceIp,proto3" json:"interface_ip,omitempty"`
+	ActiveSessions    []*SessionInfo         `protobuf:"bytes,7,rep,name=active_sessions,json=activeSessions,proto3" json:"active_sessions,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -105,6 +106,65 @@ func (x *NodeStream) GetInterfaceIp() string {
 	return ""
 }
 
+func (x *NodeStream) GetActiveSessions() []*SessionInfo {
+	if x != nil {
+		return x.ActiveSessions
+	}
+	return nil
+}
+
+type SessionInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Port          int32                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionInfo) Reset() {
+	*x = SessionInfo{}
+	mi := &file_internal_proto_v1_herd_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionInfo) ProtoMessage() {}
+
+func (x *SessionInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_proto_v1_herd_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionInfo.ProtoReflect.Descriptor instead.
+func (*SessionInfo) Descriptor() ([]byte, []int) {
+	return file_internal_proto_v1_herd_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *SessionInfo) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *SessionInfo) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
 type CloudCommand struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CommandId     string                 `protobuf:"bytes,1,opt,name=command_id,json=commandId,proto3" json:"command_id,omitempty"`
@@ -116,7 +176,7 @@ type CloudCommand struct {
 
 func (x *CloudCommand) Reset() {
 	*x = CloudCommand{}
-	mi := &file_internal_proto_v1_herd_proto_msgTypes[1]
+	mi := &file_internal_proto_v1_herd_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -128,7 +188,7 @@ func (x *CloudCommand) String() string {
 func (*CloudCommand) ProtoMessage() {}
 
 func (x *CloudCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_proto_v1_herd_proto_msgTypes[1]
+	mi := &file_internal_proto_v1_herd_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -141,7 +201,7 @@ func (x *CloudCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloudCommand.ProtoReflect.Descriptor instead.
 func (*CloudCommand) Descriptor() ([]byte, []int) {
-	return file_internal_proto_v1_herd_proto_rawDescGZIP(), []int{1}
+	return file_internal_proto_v1_herd_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *CloudCommand) GetCommandId() string {
@@ -169,7 +229,7 @@ var File_internal_proto_v1_herd_proto protoreflect.FileDescriptor
 
 const file_internal_proto_v1_herd_proto_rawDesc = "" +
 	"\n" +
-	"\x1cinternal/proto/v1/herd.proto\x12\aherd.v1\"\xf3\x01\n" +
+	"\x1cinternal/proto/v1/herd.proto\x12\aherd.v1\"\xb2\x02\n" +
 	"\n" +
 	"NodeStream\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\tR\x06nodeId\x12.\n" +
@@ -177,7 +237,12 @@ const file_internal_proto_v1_herd_proto_rawDesc = "" +
 	"\x0factive_vm_count\x18\x03 \x01(\x05R\ractiveVmCount\x12*\n" +
 	"\x11cpu_usage_percent\x18\x04 \x01(\x01R\x0fcpuUsagePercent\x12%\n" +
 	"\x0euptime_seconds\x18\x05 \x01(\x03R\ruptimeSeconds\x12!\n" +
-	"\finterface_ip\x18\x06 \x01(\tR\vinterfaceIp\"\xbb\x01\n" +
+	"\finterface_ip\x18\x06 \x01(\tR\vinterfaceIp\x12=\n" +
+	"\x0factive_sessions\x18\a \x03(\v2\x14.herd.v1.SessionInfoR\x0eactiveSessions\"@\n" +
+	"\vSessionInfo\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\xbb\x01\n" +
 	"\fCloudCommand\x12\x1d\n" +
 	"\n" +
 	"command_id\x18\x01 \x01(\tR\tcommandId\x12\x16\n" +
@@ -201,21 +266,23 @@ func file_internal_proto_v1_herd_proto_rawDescGZIP() []byte {
 	return file_internal_proto_v1_herd_proto_rawDescData
 }
 
-var file_internal_proto_v1_herd_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_internal_proto_v1_herd_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internal_proto_v1_herd_proto_goTypes = []any{
 	(*NodeStream)(nil),   // 0: herd.v1.NodeStream
-	(*CloudCommand)(nil), // 1: herd.v1.CloudCommand
-	nil,                  // 2: herd.v1.CloudCommand.ParamsEntry
+	(*SessionInfo)(nil),  // 1: herd.v1.SessionInfo
+	(*CloudCommand)(nil), // 2: herd.v1.CloudCommand
+	nil,                  // 3: herd.v1.CloudCommand.ParamsEntry
 }
 var file_internal_proto_v1_herd_proto_depIdxs = []int32{
-	2, // 0: herd.v1.CloudCommand.params:type_name -> herd.v1.CloudCommand.ParamsEntry
-	0, // 1: herd.v1.HerdControlPlane.Connect:input_type -> herd.v1.NodeStream
-	1, // 2: herd.v1.HerdControlPlane.Connect:output_type -> herd.v1.CloudCommand
-	2, // [2:3] is the sub-list for method output_type
-	1, // [1:2] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	1, // 0: herd.v1.NodeStream.active_sessions:type_name -> herd.v1.SessionInfo
+	3, // 1: herd.v1.CloudCommand.params:type_name -> herd.v1.CloudCommand.ParamsEntry
+	0, // 2: herd.v1.HerdControlPlane.Connect:input_type -> herd.v1.NodeStream
+	2, // 3: herd.v1.HerdControlPlane.Connect:output_type -> herd.v1.CloudCommand
+	3, // [3:4] is the sub-list for method output_type
+	2, // [2:3] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_internal_proto_v1_herd_proto_init() }
@@ -229,7 +296,7 @@ func file_internal_proto_v1_herd_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_proto_v1_herd_proto_rawDesc), len(file_internal_proto_v1_herd_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/v1/herd.proto
+++ b/internal/proto/v1/herd.proto
@@ -14,6 +14,12 @@ message NodeStream {
   double cpu_usage_percent = 4;
   int64 uptime_seconds = 5;
   string interface_ip = 6;
+  repeated SessionInfo active_sessions = 7;
+}
+
+message SessionInfo {
+  string session_id = 1;
+  int32 port = 2;
 }
 
 message CloudCommand {

--- a/pool.go
+++ b/pool.go
@@ -208,6 +208,11 @@ func (p *Pool[C]) Acquire(ctx context.Context, sessionID string, config TenantCo
 	}
 }
 
+// ListSessions returns a snapshot of all currently active sessionID -> Worker mappings.
+func (p *Pool[C]) ListSessions(ctx context.Context) (map[string]Worker[C], error) {
+	return p.registry.List(ctx)
+}
+
 func (p *Pool[C]) GetSession(ctx context.Context, sessionID string) (*Session[C], error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
This pull request introduces a new `Controller` abstraction to centralize and simplify session management, lifecycle operations, and logging for the daemon and cloud control plane. The changes refactor the API handler and cloud client to use this controller, improving maintainability and paving the way for more advanced orchestration features.

**Main highlights:**

### Controller Abstraction and Refactoring

* Introduced a new `Controller` type in `internal/daemon/controller.go` that encapsulates session creation, deletion, heartbeat, session listing, log retrieval, and image warming logic, moving these responsibilities out of the HTTP handler and cloud client. (`[internal/daemon/controller.goR1-R162](diffhunk://#diff-c4543adf547dce34a7bbfcc9330d87efe2517282cf1e54782f2c145d52f1aed8R1-R162)`)
* Refactored `internal/daemon/api.go` to use the new `Controller` for all session and lifecycle operations, greatly simplifying the handler code and reducing duplication. (`[[1]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL9-R21)`, `[[2]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL66-L78)`, `[[3]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL89-R74)`, `[[4]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL134-R105)`, `[[5]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL235-R131)`, `[[6]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL265-R145)`, `[[7]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL300-R190)`, `[[8]](diffhunk://#diff-19c0dae8a8e779d9fd35fb0e9fe803cad8f9040430c412e4ab582cc92bfef19fL325-R205)`)
* Updated the daemon startup (`cmd/herd/start.go`) to initialize and wire up the `Controller` and pass it to both the API handler and the cloud client. (`[cmd/herd/start.goR109-R127](diffhunk://#diff-4cf15602fb33e8ebbd1b0c8d5c717d727360ab025c5b527bb64207d3240acd40R109-R127)`)

### Cloud Control Plane Integration

* The cloud client now receives a reference to the `Controller`, allowing it to boot VMs and report accurate telemetry, including live session stats and details, via the control plane. (`[[1]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eR13-R15)`, `[[2]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eR28-R34)`, `[[3]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eR44)`, `[[4]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eL63-R67)`, `[[5]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eL80-R123)`, `[[6]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eL121-R166)`)
* Implemented the `"boot_vm"` command in the cloud client, which delegates VM creation to the controller and supports basic image selection and port mapping. (`[internal/cloud/client.goL121-R166](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eL121-R166)`)

### Telemetry and Session Reporting Improvements

* Telemetry sent to the cloud control plane now includes live stats from the session pool and active session details, instead of static/dummy values. (`[internal/cloud/client.goL80-R123](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eL80-R123)`)

These changes make the codebase more modular and easier to extend for future features such as advanced orchestration, richer telemetry, and improved cloud integration.