### PR TITLE
Secure Credential Swap

### DIFF
--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -32,8 +32,8 @@ var (
 	maxGlobalVMs   int
 	maxGlobalMemMB int64
 	cpuLimitCores  float64
-	cloudEndpoint  string
-	nodeID         string
+	cloudEndpoint string
+	machineToken  string
 )
 
 var initCmd = &cobra.Command{
@@ -55,7 +55,7 @@ func init() {
 	initCmd.Flags().Int64Var(&maxGlobalMemMB, "max-memory", 0, "Max global memory in MB")
 	initCmd.Flags().Float64Var(&cpuLimitCores, "cpu-cores", 0, "CPU limit in cores")
 	initCmd.Flags().StringVar(&cloudEndpoint, "cloud-endpoint", "", "Cloud control plane endpoint (e.g. grpc.herdcore.io:443)")
-	initCmd.Flags().StringVar(&nodeID, "node-id", "", "Unique node identifier for cloud registration")
+	initCmd.Flags().StringVar(&machineToken, "machine-token", "", "Token for machine identity authentication")
 
 	rootCmd.AddCommand(initCmd)
 }
@@ -273,9 +273,9 @@ func runInit() {
 			MetricsPath: "/metrics",
 		},
 		Cloud: config.CloudConfig{
-			Enabled:  cloudEndpoint != "" && nodeID != "",
-			Endpoint: cloudEndpoint,
-			NodeID:   nodeID,
+			Enabled:      cloudEndpoint != "" && machineToken != "",
+			Endpoint:     cloudEndpoint,
+			MachineToken: machineToken,
 		},
 	}
 

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -219,12 +219,12 @@ func (c *Client) persistIdentity(nodeID, nodeKey string) error {
 	os.Remove(c.cfg.NodeKeyPath)
 
 	// Write key with restricted permissions
-	if err := os.WriteFile(c.cfg.NodeKeyPath, []byte(nodeKey), 0400); err != nil {
+	if err := os.WriteFile(c.cfg.NodeKeyPath, []byte(nodeKey), 0600); err != nil {
 		return err
 	}
 
 	idPath := filepath.Join(dir, "node.id")
-	return os.WriteFile(idPath, []byte(nodeID), 0644)
+	return os.WriteFile(idPath, []byte(nodeID), 0400)
 }
 
 func (c *Client) Close() {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -224,7 +224,7 @@ func (c *Client) persistIdentity(nodeID, nodeKey string) error {
 	}
 
 	idPath := filepath.Join(dir, "node.id")
-	return os.WriteFile(idPath, []byte(nodeID), 0400)
+	return os.WriteFile(idPath, []byte(nodeID), 0600)
 }
 
 func (c *Client) Close() {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/herd-core/herd"
@@ -195,13 +196,13 @@ func (c *Client) commandLoop(ctx context.Context) {
 func (c *Client) loadLocalIdentity() {
 	keyData, err := os.ReadFile(c.cfg.NodeKeyPath)
 	if err == nil {
-		c.cfg.NodeKey = string(keyData)
+		c.cfg.NodeKey = strings.TrimSpace(string(keyData))
 	}
 
 	idPath := filepath.Join(filepath.Dir(c.cfg.NodeKeyPath), "node.id")
 	idData, err := os.ReadFile(idPath)
 	if err == nil {
-		c.cfg.NodeID = string(idData)
+		c.cfg.NodeID = strings.TrimSpace(string(idData))
 	}
 }
 
@@ -213,6 +214,9 @@ func (c *Client) persistIdentity(nodeID, nodeKey string) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
+
+	// P0 Fix: Remove existing read-only file before writing a new one
+	os.Remove(c.cfg.NodeKeyPath)
 
 	// Write key with restricted permissions
 	if err := os.WriteFile(c.cfg.NodeKeyPath, []byte(nodeKey), 0400); err != nil {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/herd-core/herd"
@@ -18,12 +19,12 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
 )
 
 // Client handles the bidirectional gRPC stream to the Elixir Control Plane.
 type Client struct {
 	cfg         config.CloudConfig
-	nodeID      string
 	interfaceIP string
 	controller  *daemon.Controller
 	client      herdv1.HerdControlPlaneClient
@@ -32,14 +33,8 @@ type Client struct {
 }
 
 func NewClient(cfg config.CloudConfig, interfaceIP string, controller *daemon.Controller) *Client {
-	nodeID := cfg.NodeID
-	if nodeID == "" {
-		host, _ := os.Hostname()
-		nodeID = host
-	}
 	return &Client{
 		cfg:         cfg,
-		nodeID:      nodeID,
 		interfaceIP: interfaceIP,
 		controller:  controller,
 	}
@@ -58,14 +53,29 @@ func (c *Client) Start(ctx context.Context) error {
 	}
 	c.conn = conn
 	c.client = herdv1.NewHerdControlPlaneClient(conn)
+	c.loadLocalIdentity()
 
-	stream, err := c.client.Connect(ctx)
+	var authCtx context.Context
+	if c.cfg.NodeKey != "" && c.cfg.NodeID != "" {
+		log.Printf("Authenticating with persistent NodeKey for ID: %s", c.cfg.NodeID)
+		authCtx = metadata.AppendToOutgoingContext(ctx,
+			"x-node-id", c.cfg.NodeID,
+			"x-node-key", c.cfg.NodeKey,
+		)
+	} else if c.cfg.MachineToken != "" {
+		log.Printf("Authenticating with one-time Machine Token")
+		authCtx = metadata.AppendToOutgoingContext(ctx, "x-machine-token", c.cfg.MachineToken)
+	} else {
+		return fmt.Errorf("no authentication credentials available (machine token or node key)")
+	}
+
+	stream, err := c.client.Connect(authCtx)
 	if err != nil {
 		return fmt.Errorf("failed to open stream: %w", err)
 	}
 	c.stream = stream
 	c.sendTelemetry(ctx) // Send initial telemetry immediately
-	log.Printf("Cloud Control Plane connected! NodeID: %s", c.nodeID)
+	log.Printf("Cloud Control Plane connected!")
 
 	// Start telemetry heartbeat
 	go c.telemetryLoop(ctx)
@@ -114,7 +124,6 @@ func (c *Client) sendTelemetry(ctx context.Context) error {
 	}
 
 	return c.stream.Send(&herdv1.NodeStream{
-		NodeId:            c.nodeID,
 		AvailableMemoryMb: stats.Node.AvailableMemoryBytes / 1024 / 1024,
 		ActiveVmCount:     int32(stats.ActiveSessions),
 		CpuUsagePercent:   (1.0 - stats.Node.CPUIdle) * 100.0,
@@ -164,7 +173,54 @@ func (c *Client) commandLoop(ctx context.Context) {
 		if cmd.Action == "destroy_all" {
 			log.Printf("Received destroy_all command")
 		}
+
+		if cmd.Action == "swap_credentials" {
+			nodeID := cmd.Params["node_id"]
+			nodeKey := cmd.Params["node_key"]
+			if nodeID == "" || nodeKey == "" {
+				log.Printf("received malformed swap_credentials command")
+				continue
+			}
+
+			log.Printf("Credential Swap triggered! Persisting new NodeKey for ID: %s", nodeID)
+			if err := c.persistIdentity(nodeID, nodeKey); err != nil {
+				log.Printf("failed to persist new identity: %v", err)
+				continue
+			}
+			log.Printf("✅ NodeKey persisted to %s. One-time token approach is now superseded.", c.cfg.NodeKeyPath)
+		}
 	}
+}
+
+func (c *Client) loadLocalIdentity() {
+	keyData, err := os.ReadFile(c.cfg.NodeKeyPath)
+	if err == nil {
+		c.cfg.NodeKey = string(keyData)
+	}
+
+	idPath := filepath.Join(filepath.Dir(c.cfg.NodeKeyPath), "node.id")
+	idData, err := os.ReadFile(idPath)
+	if err == nil {
+		c.cfg.NodeID = string(idData)
+	}
+}
+
+func (c *Client) persistIdentity(nodeID, nodeKey string) error {
+	c.cfg.NodeID = nodeID
+	c.cfg.NodeKey = nodeKey
+
+	dir := filepath.Dir(c.cfg.NodeKeyPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	// Write key with restricted permissions
+	if err := os.WriteFile(c.cfg.NodeKeyPath, []byte(nodeKey), 0400); err != nil {
+		return err
+	}
+
+	idPath := filepath.Join(dir, "node.id")
+	return os.WriteFile(idPath, []byte(nodeID), 0644)
 }
 
 func (c *Client) Close() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,9 +43,9 @@ type CloudConfig struct {
 	Enabled      bool   `yaml:"enabled"`
 	Endpoint     string `yaml:"endpoint"`
 	MachineToken string `yaml:"machine_token"`
-	NodeKey      string `yaml:"node_key"`
+	NodeKey      string `yaml:"-"`
 	NodeKeyPath  string `yaml:"node_key_path"`
-	NodeID       string `yaml:"node_id"` // Used for reconnection
+	NodeID       string `yaml:"-"` // Used for reconnection
 	Interface    string `yaml:"interface"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 
 	"gopkg.in/yaml.v3"
@@ -39,10 +40,13 @@ type Config struct {
 }
 
 type CloudConfig struct {
-	Enabled         bool   `yaml:"enabled"`
-	Endpoint        string `yaml:"endpoint"`
-	NodeID          string `yaml:"node_id"`
-	Interface 		string `yaml:"interface"`
+	Enabled      bool   `yaml:"enabled"`
+	Endpoint     string `yaml:"endpoint"`
+	MachineToken string `yaml:"machine_token"`
+	NodeKey      string `yaml:"node_key"`
+	NodeKeyPath  string `yaml:"node_key_path"`
+	NodeID       string `yaml:"node_id"` // Used for reconnection
+	Interface    string `yaml:"interface"`
 }
 
 type BinaryConfig struct {
@@ -129,6 +133,14 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Network.EphemeralPortEnd == 0 {
 		c.Network.EphemeralPortEnd = 39999
+	}
+	if c.Cloud.NodeKeyPath == "" {
+		home, _ := GetTargetHomeDir()
+		if home != "" {
+			c.Cloud.NodeKeyPath = filepath.Join(home, ".herd", "node.key")
+		} else {
+			c.Cloud.NodeKeyPath = "/etc/herd/node.key"
+		}
 	}
 }
 

--- a/internal/proto/v1/herd.proto
+++ b/internal/proto/v1/herd.proto
@@ -8,7 +8,8 @@ service HerdControlPlane {
 }
 
 message NodeStream {
-  string node_id = 1;
+  reserved 1;
+  reserved "node_id";
   int64 available_memory_mb = 2;
   int32 active_vm_count = 3;
   double cpu_usage_percent = 4;


### PR DESCRIPTION
This pull request introduces a new authentication flow for connecting nodes to the cloud control plane, replacing the previous `node-id` approach with a more secure, token-based system. The changes support one-time machine tokens for initial authentication, with the ability to persist a long-term node identity and key. The configuration and client logic have been updated to handle these new credentials, and the proto definition has been adjusted accordingly.

**Authentication and Identity Management:**

* Replaced `node-id` with `machine-token` for initial cloud registration in both command-line flags and configuration (`cmd/herd/init.go`, `internal/config/config.go`). [[1]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L36-R36) [[2]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L58-R58) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL44-R48)
* Added support for persistent node identity via `node_key` and `node_id`, including logic to load and persist these credentials locally after a successful credential swap (`internal/cloud/client.go`). [[1]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eR56-R78) [[2]](diffhunk://#diff-196a499cf48a01c70fcd87cbfc81ec92b31fe8bf12acc7dc0ab322c07da5e72eR176-R223) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL44-R48)

**Configuration Enhancements:**

* Introduced `node_key_path` to specify where the node key is stored, with sensible defaults applied if not set (`internal/config/config.go`). [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL44-R48) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR137-R144)

**gRPC and Protocol Adjustments:**

* Updated the gRPC connection logic to send either a one-time machine token or persistent node credentials via metadata, depending on what is available (`internal/cloud/client.go`).
* Removed the `node_id` field from the `NodeStream` proto message, reflecting the new authentication model (`internal/proto/v1/herd.proto`).

These changes improve security and flexibility in node authentication and lifecycle management for cloud-connected nodes.