### PR TITLE
fix go fmt

### DIFF
--- a/firecracker_factory.go
+++ b/firecracker_factory.go
@@ -35,8 +35,8 @@ type FirecrackerFactory struct {
 	// GuestAgentPath is the host path to the static herd-guest-agent binary.
 	GuestAgentPath string
 
-	Storage *storage.Manager
-	IPAM    *network.IPAM
+	Storage     *storage.Manager
+	IPAM        *network.IPAM
 	PortManager *network.PortManager
 
 	// UIDPool is the per-VM UID/GID allocator. Each Spawn leases a unique UID
@@ -59,21 +59,21 @@ func (f *FirecrackerFactory) chrootRoot(vmID string) string {
 
 // FirecrackerWorker represents a single running Firecracker VM.
 type FirecrackerWorker struct {
-	storage    *storage.Manager
-	id         string
-	socketPath string
-	tapName    string
-	guestIP    string
-	cmd        *exec.Cmd
-	client     *http.Client
-	ipam       *network.IPAM
-	chrootDir  string             // full chroot root path; removed on Close()
-	done       chan struct{}       // closed when cmd.Wait() returns
-	ctx        context.Context    // lifecycle context for the worker
-	cancel     context.CancelFunc // cancelled on Close()
-	leasedUID    int                // UID leased from UIDPool for this VM
-	uidPool      *uid.Pool          // pool to return the UID to on Close()
-	portMappings []PortMapping      // active port forwards on the host
+	storage      *storage.Manager
+	id           string
+	socketPath   string
+	tapName      string
+	guestIP      string
+	cmd          *exec.Cmd
+	client       *http.Client
+	ipam         *network.IPAM
+	chrootDir    string               // full chroot root path; removed on Close()
+	done         chan struct{}        // closed when cmd.Wait() returns
+	ctx          context.Context      // lifecycle context for the worker
+	cancel       context.CancelFunc   // cancelled on Close()
+	leasedUID    int                  // UID leased from UIDPool for this VM
+	uidPool      *uid.Pool            // pool to return the UID to on Close()
+	portMappings []PortMapping        // active port forwards on the host
 	portManager  *network.PortManager // manager to release ports to on Close()
 }
 
@@ -437,7 +437,6 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	})
 	log.Printf("[spawn:%s] cmd.Start        %v", workerID, time.Since(t3))
 
-
 	// Wait for the VM to boot and accept vsock connections.
 	t4 := time.Now()
 	deadline := time.Now().Add(30 * time.Second)
@@ -536,22 +535,22 @@ func (f *FirecrackerFactory) Spawn(ctx context.Context, sessionID string, config
 	}
 
 	return &FirecrackerWorker{
-		id:            workerID,
-		socketPath:    socketPath,
-		tapName:       tapName,
-		guestIP:       guestIP,
-		cmd:           cmd,
-		client:        agentClient,
-		storage:       f.Storage,
-		ipam:          f.IPAM,
-		chrootDir:     chrootRoot,
-		done:          done,
-		ctx:           workerCtx,
-		cancel:        workerCancel,
-		leasedUID:     leasedUID,
-		uidPool:       f.UIDPool,
-		portMappings:  activeMappings,
-		portManager:   f.PortManager,
+		id:           workerID,
+		socketPath:   socketPath,
+		tapName:      tapName,
+		guestIP:      guestIP,
+		cmd:          cmd,
+		client:       agentClient,
+		storage:      f.Storage,
+		ipam:         f.IPAM,
+		chrootDir:    chrootRoot,
+		done:         done,
+		ctx:          workerCtx,
+		cancel:       workerCancel,
+		leasedUID:    leasedUID,
+		uidPool:      f.UIDPool,
+		portMappings: activeMappings,
+		portManager:  f.PortManager,
 	}, nil
 }
 

--- a/pool.go
+++ b/pool.go
@@ -26,7 +26,6 @@
 //  6. Lock → sessions[sessionID]=w, delete inflight[sid], close(ch) → unlock.
 //     Closing ch broadcasts to all goroutines waiting in step 2.
 //  7. Return &Session[C]{…}
-//
 package herd
 
 import (
@@ -43,7 +42,7 @@ import (
 // ---------------------------------------------------------------------------
 
 type Session[C any] struct {
-	ID string
+	ID     string
 	Worker Worker[C]
 
 	pool *Pool[C]
@@ -61,10 +60,10 @@ func (s *Session[C]) Release() {
 // ---------------------------------------------------------------------------
 
 type PoolStats struct {
-	TotalWorkers int
-	ActiveSessions int
+	TotalWorkers     int
+	ActiveSessions   int
 	InflightAcquires int
-	Node observer.NodeStats
+	Node             observer.NodeStats
 }
 
 // ---------------------------------------------------------------------------
@@ -75,14 +74,14 @@ type Pool[C any] struct {
 	factory WorkerFactory[C]
 	cfg     config
 
-	mu          sync.Mutex
-	registry    SessionRegistry[C]
-	inflight    map[string]chan struct{}
+	mu       sync.Mutex
+	registry SessionRegistry[C]
+	inflight map[string]chan struct{}
 
 	workers []Worker[C]
 	tickets chan struct{}
 
-	done chan struct{}
+	done   chan struct{}
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -96,15 +95,15 @@ func New[C any](factory WorkerFactory[C], opts ...Option) (*Pool[C], error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	p := &Pool[C]{
-		factory:   factory,
-		cfg:       cfg,
-		registry:  NewLocalRegistry[C](),
-		inflight:  make(map[string]chan struct{}),
-		workers:   make([]Worker[C], 0, cfg.max),
-		tickets:   make(chan struct{}, cfg.max),
-		done:      make(chan struct{}),
-		ctx:       ctx,
-		cancel:    cancel,
+		factory:  factory,
+		cfg:      cfg,
+		registry: NewLocalRegistry[C](),
+		inflight: make(map[string]chan struct{}),
+		workers:  make([]Worker[C], 0, cfg.max),
+		tickets:  make(chan struct{}, cfg.max),
+		done:     make(chan struct{}),
+		ctx:      ctx,
+		cancel:   cancel,
 	}
 
 	for i := 0; i < cfg.max; i++ {


### PR DESCRIPTION
This pull request contains minor cleanup changes to documentation and formatting. No functional or behavioral changes are introduced.

- Documentation cleanup:
  * [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L29): Removed an unnecessary trailing comment delimiter at the end of the file header comments.

- Formatting:
  * [`firecracker_factory.go`](diffhunk://#diff-3914f2047acf020c74f3f40df7c2f99eea93b7f19c2d271354c140d5cf11d48eL440): Removed an extra blank line for improved code readability.