### PR TITLE
Improved port mapping logic in deploy command

### DIFF
--- a/cmd/herd-guest-agent/main.go
+++ b/cmd/herd-guest-agent/main.go
@@ -285,7 +285,7 @@ func mountContainerFilesystems() error {
 func configureNetworking() error {
 	// Wait a moment for TAP interface to visibly attach to the VM
 	// in some hypervisor configurations.
-	
+
 	// 1. Loopback
 	lo, err := netlink.LinkByName("lo")
 	if err != nil {

--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -3,71 +3,17 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/herd-core/herd/internal/config"
+	"github.com/herd-core/herd/internal/network"
 	"github.com/spf13/cobra"
 )
-
-func splitNetworkBindings(bindings string) (string, int8, int8) {
-	// we assume perfect bindings of the format interface:host_port:guest_port
-	parts := strings.Split(bindings, ":")
-	intface := parts[0]
-	hostPort, err := strconv.ParseInt(parts[1], 10, 8) 
-	if err != nil {
-		fmt.Println("Unable to parse host network bindings")
-	}
-	guestPort, err := strconv.ParseInt(parts[2], 10, 8)
-	if err != nil {
-		fmt.Println("Unable to parse guest network bindings")
-	}
-	return intface, int8(hostPort), int8(guestPort) 
-}
-
-func sanitizeNetworkBindings(bindings string) (string, string, error) {
-	
-	// could be of the format 
-	// int:host:guest{/protocol|}
-	// host:guest{/protocol|}
-	// :guest{/protocol|}
-	
-	// resolve and split protocol first
-	addrPart := bindings
-	protocol := "tcp" // defaults to tcp protocol
-
-	if protoParts := strings.Split(bindings, "/"); len(protoParts) == 2 {
-		addrPart = protoParts[0]
-		protocol = strings.ToLower(protoParts[1])
-	}
-
-	splitCount := strings.Count(addrPart, ":")
-	formattedBinding := addrPart
-	switch splitCount {
-		case 1:
-			if addrPart[0] == ':' {
-				formattedBinding = "0.0.0.0:0" + formattedBinding
-			}
-			formattedBinding = "0.0.0.0:" + addrPart
-	
-		default:
-			return "", "", errors.New("Invalid network binding format")
-	}
-	splitParts := strings.Split(formattedBinding, ":")
-	for _, part := range splitParts {
-		if len(part) < 1 {
-			return "", "", errors.New("Invalid network binding format")
-		}
-	}
-
-	return formattedBinding, protocol, nil
-}
 
 var (
 	deployImage   string
@@ -111,13 +57,13 @@ var deployCmd = &cobra.Command{
 		if len(deployPublish) > 0 {
 			mappings := make([]map[string]any, 0, len(deployPublish))
 			for _, p := range deployPublish {
-				sanitizedBindings, protocol, err := sanitizeNetworkBindings(p)
+				sanitizedBindings, protocol, err := network.SanitizeNetworkBindings(p)
 				if err != nil {
 					log.Fatalf("invalid port mappings, %e", err)
 				}
-				
-				intface, hport, gport := splitNetworkBindings(sanitizedBindings)
-				
+
+				intface, hport, gport := network.SplitNetworkBindings(sanitizedBindings)
+
 				m := map[string]any {
 					"host_interface": intface,
 					"protocol": protocol,

--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -57,18 +57,16 @@ var deployCmd = &cobra.Command{
 		if len(deployPublish) > 0 {
 			mappings := make([]map[string]any, 0, len(deployPublish))
 			for _, p := range deployPublish {
-				sanitizedBindings, protocol, err := network.SanitizeNetworkBindings(p)
+				bindings, err := network.SanitizeNetworkBindings(p)
 				if err != nil {
-					log.Fatalf("invalid port mappings, %e", err)
+					log.Fatalf("Invalid Port Bindings %e", err)
 				}
 
-				intface, hport, gport := network.SplitNetworkBindings(sanitizedBindings)
-
 				m := map[string]any{
-					"host_interface": intface,
-					"protocol":       protocol,
-					"host_port":      hport,
-					"guest_port":     gport,
+					"host_interface": bindings.IP,
+					"protocol":       bindings.Protocol,
+					"host_port":      bindings.HostPort,
+					"guest_port":     bindings.GuestPort,
 				}
 
 				mappings = append(mappings, m)

--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +15,59 @@ import (
 	"github.com/herd-core/herd/internal/config"
 	"github.com/spf13/cobra"
 )
+
+func splitNetworkBindings(bindings string) (string, int8, int8) {
+	// we assume perfect bindings of the format interface:host_port:guest_port
+	parts := strings.Split(bindings, ":")
+	intface := parts[0]
+	hostPort, err := strconv.ParseInt(parts[1], 10, 8) 
+	if err != nil {
+		fmt.Println("Unable to parse host network bindings")
+	}
+	guestPort, err := strconv.ParseInt(parts[2], 10, 8)
+	if err != nil {
+		fmt.Println("Unable to parse guest network bindings")
+	}
+	return intface, int8(hostPort), int8(guestPort) 
+}
+
+func sanitizeNetworkBindings(bindings string) (string, string, error) {
+	
+	// could be of the format 
+	// int:host:guest{/protocol|}
+	// host:guest{/protocol|}
+	// :guest{/protocol|}
+	
+	// resolve and split protocol first
+	addrPart := bindings
+	protocol := "tcp" // defaults to tcp protocol
+
+	if protoParts := strings.Split(bindings, "/"); len(protoParts) == 2 {
+		addrPart = protoParts[0]
+		protocol = strings.ToLower(protoParts[1])
+	}
+
+	splitCount := strings.Count(addrPart, ":")
+	formattedBinding := addrPart
+	switch splitCount {
+		case 1:
+			if addrPart[0] == ':' {
+				formattedBinding = "0.0.0.0:0" + formattedBinding
+			}
+			formattedBinding = "0.0.0.0:" + addrPart
+	
+		default:
+			return "", "", errors.New("Invalid network binding format")
+	}
+	splitParts := strings.Split(formattedBinding, ":")
+	for _, part := range splitParts {
+		if len(part) < 1 {
+			return "", "", errors.New("Invalid network binding format")
+		}
+	}
+
+	return formattedBinding, protocol, nil
+}
 
 var (
 	deployImage   string
@@ -36,8 +90,8 @@ var deployCmd = &cobra.Command{
 		
 		req := map[string]any{
 			"image":                deployImage,
-			"idle_timeout_seconds": deployTimeout,
-			"ttl_seconds": absoluteDeployTimeout,
+			"idle_timeout_seconds": deployTimeout, // TODO: fix why do we have these names so different, they are just gonna create confusion down the reoad
+			"ttl_seconds": absoluteDeployTimeout,  // I currently have no idea what ttl seconds mean and what idle timeout seconds mean
 		}
 		if len(deployCommand) > 0 {
 			req["command"] = deployCommand
@@ -57,54 +111,20 @@ var deployCmd = &cobra.Command{
 		if len(deployPublish) > 0 {
 			mappings := make([]map[string]any, 0, len(deployPublish))
 			for _, p := range deployPublish {
-				protocol := "tcp"
-				addrPart := p
-				if protoParts := strings.Split(p, "/"); len(protoParts) == 2 {
-					addrPart = protoParts[0]
-					protocol = strings.ToLower(protoParts[1])
+				sanitizedBindings, protocol, err := sanitizeNetworkBindings(p)
+				if err != nil {
+					log.Fatalf("invalid port mappings, %e", err)
 				}
-
-				m := map[string]any{
+				
+				intface, hport, gport := splitNetworkBindings(sanitizedBindings)
+				
+				m := map[string]any {
+					"host_interface": intface,
 					"protocol": protocol,
+					"host_port": hport,
+					"guest_port": gport,
 				}
-				parts := strings.Split(addrPart, ":")
-
-				if len(parts) == 2 {
-					// host_port:guest_port OR :guest_port
-					if parts[0] == "" {
-						// :80
-						m["host_port"] = 0
-						m["host_interface"] = "0.0.0.0"
-					} else {
-						// 8080:80
-						hPort, err := strconv.Atoi(parts[0])
-						if err != nil {
-							log.Fatalf("invalid host port %q in publish flag %q: %v", parts[0], p, err)
-						}
-						m["host_port"] = hPort
-						m["host_interface"] = "0.0.0.0"
-					}
-					gPort, err := strconv.Atoi(parts[1])
-					if err != nil {
-						log.Fatalf("invalid guest port %q in publish flag %q: %v", parts[1], p, err)
-					}
-					m["guest_port"] = gPort
-				} else if len(parts) == 3 {
-					// interface:host_port:guest_port
-					m["host_interface"] = parts[0]
-					hPort, err := strconv.Atoi(parts[1])
-					if err != nil {
-						log.Fatalf("invalid host port %q in publish flag %q: %v", parts[1], p, err)
-					}
-					gPort, err := strconv.Atoi(parts[2])
-					if err != nil {
-						log.Fatalf("invalid guest port %q in publish flag %q: %v", parts[2], p, err)
-					}
-					m["host_port"] = hPort
-					m["guest_port"] = gPort
-				} else {
-					log.Fatalf("invalid publish format %q: expected [[interface:]host_port]:guest_port[/protocol]", p)
-				}
+				
 				mappings = append(mappings, m)
 			}
 			req["port_mappings"] = mappings

--- a/cmd/herd/deploy.go
+++ b/cmd/herd/deploy.go
@@ -16,12 +16,12 @@ import (
 )
 
 var (
-	deployImage   string
-	deployTimeout int
+	deployImage           string
+	deployTimeout         int
 	absoluteDeployTimeout int
-	deployCommand []string
-	deployEnv     []string
-	deployPublish []string
+	deployCommand         []string
+	deployEnv             []string
+	deployPublish         []string
 )
 
 var deployCmd = &cobra.Command{
@@ -33,11 +33,11 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("failed to load config %q: %v", configPath, err)
 		}
-		
+
 		req := map[string]any{
 			"image":                deployImage,
-			"idle_timeout_seconds": deployTimeout, // TODO: fix why do we have these names so different, they are just gonna create confusion down the reoad
-			"ttl_seconds": absoluteDeployTimeout,  // I currently have no idea what ttl seconds mean and what idle timeout seconds mean
+			"idle_timeout_seconds": deployTimeout,         // TODO: fix why do we have these names so different, they are just gonna create confusion down the reoad
+			"ttl_seconds":          absoluteDeployTimeout, // I currently have no idea what ttl seconds mean and what idle timeout seconds mean
 		}
 		if len(deployCommand) > 0 {
 			req["command"] = deployCommand
@@ -64,13 +64,13 @@ var deployCmd = &cobra.Command{
 
 				intface, hport, gport := network.SplitNetworkBindings(sanitizedBindings)
 
-				m := map[string]any {
+				m := map[string]any{
 					"host_interface": intface,
-					"protocol": protocol,
-					"host_port": hport,
-					"guest_port": gport,
+					"protocol":       protocol,
+					"host_port":      hport,
+					"guest_port":     gport,
 				}
-				
+
 				mappings = append(mappings, m)
 			}
 			req["port_mappings"] = mappings
@@ -84,10 +84,10 @@ var deployCmd = &cobra.Command{
 			log.Fatalf("failed to deploy: %v", err)
 		}
 		defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to close response body: %v\n", cerr)
-		}
-	}()
+			if cerr := resp.Body.Close(); cerr != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to close response body: %v\n", cerr)
+			}
+		}()
 
 		if resp.StatusCode != 200 {
 			body, _ := io.ReadAll(resp.Body)

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -306,12 +306,13 @@ func runInit() {
 // extracts both the firecracker and jailer binaries in a single HTTP round-trip.
 func downloadFirecrackerAndJailer(fcOutputPath, jailerOutputPath string) error {
 	arch := runtime.GOARCH
-	if arch == "amd64" {
+	switch arch {
+	case "amd4":
 		arch = "x86_64"
-	} else if arch == "arm64" {
+	case "arm64":
 		arch = "aarch64"
 	}
-
+	
 	version := "1.14.3"
 	url := fmt.Sprintf("https://github.com/firecracker-microvm/firecracker/releases/download/v%s/firecracker-v%s-%s.tgz", version, version, arch)
 

--- a/cmd/herd/init.go
+++ b/cmd/herd/init.go
@@ -21,8 +21,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-
-
 var (
 	autoYes        bool
 	fcBinaryPath   string
@@ -32,8 +30,8 @@ var (
 	maxGlobalVMs   int
 	maxGlobalMemMB int64
 	cpuLimitCores  float64
-	cloudEndpoint string
-	machineToken  string
+	cloudEndpoint  string
+	machineToken   string
 )
 
 var initCmd = &cobra.Command{
@@ -238,14 +236,13 @@ func runInit() {
 		fmt.Println()
 	}
 
-
 	// 5. Config Generation
 	cfg := config.Config{
 		Network: config.NetworkConfig{
-			ControlBind: "127.0.0.1:8081",
-			DataBind:    "127.0.0.1:8080",
+			ControlBind:        "127.0.0.1:8081",
+			DataBind:           "127.0.0.1:8080",
 			EphemeralPortStart: 10000,
-			EphemeralPortEnd: 39999,
+			EphemeralPortEnd:   39999,
 		},
 		Storage: config.StorageConfig{
 			StateDir:        stateDir,
@@ -312,7 +309,7 @@ func downloadFirecrackerAndJailer(fcOutputPath, jailerOutputPath string) error {
 	case "arm64":
 		arch = "aarch64"
 	}
-	
+
 	version := "1.14.3"
 	url := fmt.Sprintf("https://github.com/firecracker-microvm/firecracker/releases/download/v%s/firecracker-v%s-%s.tgz", version, version, arch)
 
@@ -497,7 +494,7 @@ func promptConfirm(reader *bufio.Reader, label string, defaultValue bool) bool {
 func downloadKernel(path string) error {
 	// Pull from a specific release instead of main for stability
 	url := fmt.Sprintf("https://github.com/herd-core/herd/releases/download/%s/vmlinux-v6.1.bin", config.Version)
-	
+
 	resp, err := http.Get(url)
 	if err != nil {
 		return err

--- a/cmd/herd/logs.go
+++ b/cmd/herd/logs.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	// uses global configPath
+// uses global configPath
 )
 
 var logsCmd = &cobra.Command{
@@ -21,22 +21,22 @@ var logsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]
-		
+
 		cfg, err := config.Load(configPath)
 		if err != nil {
 			log.Fatalf("failed to load config %q: %v", configPath, err)
 		}
-		
+
 		url := fmt.Sprintf("http://%s/v1/sessions/%s/logs", cfg.Network.ControlBind, sessionID)
 		resp, err := http.Get(url)
 		if err != nil {
 			log.Fatalf("failed to fetch logs: %v", err)
 		}
 		defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to close log stream body: %v\n", cerr)
-		}
-	}()
+			if cerr := resp.Body.Close(); cerr != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to close log stream body: %v\n", cerr)
+			}
+		}()
 
 		if resp.StatusCode != 200 {
 			body, _ := io.ReadAll(resp.Body)

--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -90,7 +90,7 @@ func runDaemon() {
 			eventLogger.Error("control_listener_close_failed", map[string]any{"error": err})
 		}
 	}()
-	
+
 	// Determine Public IP if interface is specified
 	var interfaceIP string
 	if interfaceName == "" {

--- a/cmd/herd/stop.go
+++ b/cmd/herd/stop.go
@@ -17,20 +17,20 @@ var stopCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]
-		
+
 		cfg, err := config.Load(configPath)
 		if err != nil {
 			log.Fatalf("failed to load config %q: %v", configPath, err)
 		}
-		
+
 		url := fmt.Sprintf("http://%s/v1/sessions/%s", cfg.Network.ControlBind, sessionID)
-		
+
 		client := &http.Client{}
 		req, err := http.NewRequest(http.MethodDelete, url, nil)
 		if err != nil {
 			log.Fatalf("failed to create request: %v", err)
 		}
-		
+
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Fatalf("failed to send request: %v", err)

--- a/cmd/herd/teardown.go
+++ b/cmd/herd/teardown.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// uses global configPath
+// uses global configPath
 )
 
 var teardownCmd = &cobra.Command{

--- a/cmd/test_boot/main.go
+++ b/cmd/test_boot/main.go
@@ -7,12 +7,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/herd-core/herd"
 	"github.com/herd-core/herd/internal/config"
 	"github.com/herd-core/herd/internal/network"
 	"github.com/herd-core/herd/internal/storage"
 	"github.com/herd-core/herd/internal/uid"
-	"github.com/containerd/containerd"
 )
 
 func main() {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -193,7 +193,7 @@ func (c *Client) commandLoop(ctx context.Context) {
 				}
 
 				resp, err := c.controller.CreateSession(ctx, req)
-				
+
 				// Send CommandResponse feedback
 				respPayload := &herdv1.CommandResponse{
 					CommandId: cmd.CommandId,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,7 +65,7 @@ type BinaryConfig struct {
 type JailerConfig struct {
 	// UIDPoolStart is the first UID (and GID) in the pool. Must be >= 65536 to
 	// stay well above system-reserved UIDs. Recommended: 300000.
-	UIDPoolStart  int    `yaml:"uid_pool_start"`
+	UIDPoolStart int `yaml:"uid_pool_start"`
 	// UIDPoolSize is how many concurrent MicroVMs the pool can support.
 	// Set this to at least your max_global_vms value.
 	UIDPoolSize   int    `yaml:"uid_pool_size"`
@@ -86,9 +86,9 @@ type NetworkConfig struct {
 }
 
 type ResourceConfig struct {
-	MaxGlobalVMs       int     `yaml:"max_global_vms"`
-	MaxGlobalMemoryMB  int64   `yaml:"max_global_memory_mb"`
-	CPULimitCores      float64 `yaml:"cpu_limit_cores"`
+	MaxGlobalVMs      int     `yaml:"max_global_vms"`
+	MaxGlobalMemoryMB int64   `yaml:"max_global_memory_mb"`
+	CPULimitCores     float64 `yaml:"cpu_limit_cores"`
 }
 
 type TelemetryConfig struct {

--- a/internal/core/os_attrs_linux.go
+++ b/internal/core/os_attrs_linux.go
@@ -18,7 +18,6 @@ func ApplyOSAttributes(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
 }
 
-// future consideration for ephermal vs non ephermal workloads whether or not to kill 
-// the child process if the parent dies, but the quesiton would remain to boot back up 
+// future consideration for ephermal vs non ephermal workloads whether or not to kill
+// the child process if the parent dies, but the quesiton would remain to boot back up
 // and rebuild the state again.
-

--- a/internal/daemon/controller.go
+++ b/internal/daemon/controller.go
@@ -169,7 +169,9 @@ func (c *Controller) GetLogs(ctx context.Context, sessionID string) (io.ReadClos
 }
 
 func (c *Controller) WarmImage(ctx context.Context, image string) error {
-	if warmer, ok := c.pool.Factory().(interface{ WarmImage(context.Context, string) error }); ok {
+	if warmer, ok := c.pool.Factory().(interface {
+		WarmImage(context.Context, string) error
+	}); ok {
 		return warmer.WarmImage(ctx, image)
 	}
 	return fmt.Errorf("warming not supported by factory")

--- a/internal/lifecycle/manager.go
+++ b/internal/lifecycle/manager.go
@@ -20,8 +20,8 @@ type SessionState struct {
 	LastDataActivity     time.Time  `json:"last_data_activity"`
 	ActiveConns          int        `json:"active_conns"`
 
-	IdleTTL     time.Duration      `json:"idle_ttl"`
-	AbsoluteTTL time.Duration      `json:"absolute_ttl"`
+	IdleTTL      time.Duration      `json:"idle_ttl"`
+	AbsoluteTTL  time.Duration      `json:"absolute_ttl"`
 	PortMappings []herd.PortMapping `json:"port_mappings"`
 }
 

--- a/internal/lifecycle/reaper.go
+++ b/internal/lifecycle/reaper.go
@@ -32,8 +32,8 @@ func (m *Manager) sweep() {
 
 	now := time.Now()
 
-	// We don't need to do UnregisterAndKill directly inside the sweep loop because 
-	// m.UnregisterAndKill explicitly acquires the global registry lock again (m.mu.Lock()), 
+	// We don't need to do UnregisterAndKill directly inside the sweep loop because
+	// m.UnregisterAndKill explicitly acquires the global registry lock again (m.mu.Lock()),
 	// which is perfectly safe since we explicitly dropped the lock (RUnlock) before the loop!
 	for id, state := range sessions {
 		state.mu.Lock()

--- a/internal/network/nat.go
+++ b/internal/network/nat.go
@@ -42,7 +42,7 @@ func Bootstrap() error {
 		return err
 	}
 
-	// Hairpin NAT Masquerade: Ensure host-to-VM traffic (e.g. from 127.0.0.1) 
+	// Hairpin NAT Masquerade: Ensure host-to-VM traffic (e.g. from 127.0.0.1)
 	// is masqueraded so the VM sees the host's bridge IP as source.
 	if err := runCmd("iptables", "-t", "nat", "-A", "POSTROUTING", "-d", Subnet, "-m", "addrtype", "--src-type", "LOCAL", "-j", "MASQUERADE"); err != nil {
 		return err
@@ -253,7 +253,6 @@ func RemovePortMapping(hostInterface string, hostPort int, guestIP string, guest
 	slog.Info("port mapping removed", "host", hostInterface, "hPort", hostPort, "gIP", guestIP, "gPort", guestPort)
 	return nil
 }
-
 
 // DeleteTap removes a TAP interface.
 func DeleteTap(name string) error {

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -1,10 +1,10 @@
 package network
 
 import (
-	"fmt"
-	"strings"
-	"strconv"
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 func SplitNetworkBindings(bindings string) (string, int8, int8) {
@@ -44,7 +44,7 @@ func SanitizeNetworkBindings(bindings string) (string, string, error) {
 	case 1:
 		if addrPart[0] == ':' {
 			formattedBinding = "0" + formattedBinding
-		} 
+		}
 		formattedBinding = "0.0.0.0:" + formattedBinding
 	default:
 		return "", "", errors.New("Invalid network binding format")

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -2,59 +2,91 @@ package network
 
 import (
 	"errors"
-	"fmt"
+	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 )
 
-func SplitNetworkBindings(bindings string) (string, int8, int8) {
-	// we assume perfect bindings of the format interface:host_port:guest_port
-	parts := strings.Split(bindings, ":")
-	intface := parts[0]
-	hostPort, err := strconv.ParseInt(parts[1], 10, 8)
-	if err != nil {
-		fmt.Println("Unable to parse host network bindings")
-	}
-	guestPort, err := strconv.ParseInt(parts[2], 10, 8)
-	if err != nil {
-		fmt.Println("Unable to parse guest network bindings")
-	}
-	return intface, int8(hostPort), int8(guestPort)
+type PortBinding struct {
+	IP        netip.Addr
+	HostPort  uint16
+	GuestPort uint16
+	Protocol  string
 }
 
-func SanitizeNetworkBindings(bindings string) (string, string, error) {
-
-	// could be of the format
-	// int:host:guest{/protocol|}
-	// host:guest{/protocol|}
-	// :guest{/protocol|}
-
-	// resolve and split protocol first
-	addrPart := bindings
-	protocol := "tcp" // defaults to tcp protocol
-
-	if protoParts := strings.Split(bindings, "/"); len(protoParts) == 2 {
-		addrPart = protoParts[0]
-		protocol = strings.ToLower(protoParts[1])
+func SanitizeNetworkBindings(input string) (PortBinding, error) {
+	// setting some default values before hand.
+	output := PortBinding{
+		IP:        netip.MustParseAddr("0.0.0.0"), // will panic if the string is bad
+		HostPort:  0,
+		GuestPort: 0,
+		Protocol:  "tcp",
 	}
+	//. okay how do I want this to work?
+	// i am gonna have some default values for the struct, then I will parse the string one by one,
+	// until I update the struct and then I will just return the struct, using this approach I dont need to do seperate
+	// binding split fn call.
 
-	splitCount := strings.Count(addrPart, ":")
-	formattedBinding := addrPart
-	switch splitCount {
-	case 1:
-		if addrPart[0] == ':' {
-			formattedBinding = "0" + formattedBinding
-		}
-		formattedBinding = "0.0.0.0:" + formattedBinding
-	default:
-		return "", "", errors.New("Invalid network binding format")
-	}
-	splitParts := strings.Split(formattedBinding, ":")
-	for _, part := range splitParts {
-		if len(part) < 1 {
-			return "", "", errors.New("Invalid network binding format")
+	input = strings.ToLower(input)
+	parts := strings.Split(input, "/")
+
+	if len(parts) > 2 {
+		return output, errors.New("Invalid network binding: More than two / splits")
+	} else if len(parts) == 2 {
+		validProtocols := []string{"tcp", "udp"}
+		// the second one is the protocol, and we need to parse and validate.
+		if slices.Contains(validProtocols, parts[1]) {
+			output.Protocol = parts[1]
+			input = parts[0] // for further processing input string is updated.
+		} else {
+			return output, errors.New("Invalid Protocol format: Must be one of tcp, udp")
 		}
 	}
 
-	return formattedBinding, protocol, nil
+	// now the input should always without '/' splits, and protocols like /tcp and /udp stripped.
+	colon_parts := strings.Split(input, ":")
+	if len(colon_parts) > 3 || len(colon_parts) == 0 {
+		return output, errors.New("Invalid network binding too many colon splits")
+	}
+
+	// reverse the list for easier processing in place
+	slices.Reverse(colon_parts)
+
+	for i, part := range colon_parts {
+		switch i {
+		case 0:
+			
+			// this is the guest port, try to parse this.
+			guestPort, err := strconv.ParseUint(part, 10, 16)
+			if err != nil || guestPort > 65535{
+				return output, errors.New("Invalid Guest Port")
+			}
+			output.GuestPort = uint16(guestPort)
+		
+		case 1:
+			if part == "" {
+				continue // skip parsing, leaves output.HostPort as the default 0
+			}
+			// this is the host port, try to parse this.
+			hostPort, err := strconv.ParseUint(part, 10, 16)
+			if err != nil || hostPort > 65535{
+				return output, errors.New("Invalid Host Port")
+			}
+			output.HostPort = uint16(hostPort)
+		
+		case 2:
+			if part == "" {
+				continue // skip parsing, leaves output.HostPort as the default 0
+			}
+			// this is the intface IP, lets parse this only restricted to IPv4
+			ipv4Addr, err := netip.ParseAddr(part)
+			if err != nil || !ipv4Addr.Is4() {
+				return output, errors.New("Invalid Interface IP: only support IPv4 interface")
+			}
+			output.IP = ipv4Addr
+		}
+	}
+
+	return output, nil
 }

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -1,0 +1,60 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+	"strconv"
+	"errors"
+)
+
+func SplitNetworkBindings(bindings string) (string, int8, int8) {
+	// we assume perfect bindings of the format interface:host_port:guest_port
+	parts := strings.Split(bindings, ":")
+	intface := parts[0]
+	hostPort, err := strconv.ParseInt(parts[1], 10, 8)
+	if err != nil {
+		fmt.Println("Unable to parse host network bindings")
+	}
+	guestPort, err := strconv.ParseInt(parts[2], 10, 8)
+	if err != nil {
+		fmt.Println("Unable to parse guest network bindings")
+	}
+	return intface, int8(hostPort), int8(guestPort)
+}
+
+func SanitizeNetworkBindings(bindings string) (string, string, error) {
+
+	// could be of the format
+	// int:host:guest{/protocol|}
+	// host:guest{/protocol|}
+	// :guest{/protocol|}
+
+	// resolve and split protocol first
+	addrPart := bindings
+	protocol := "tcp" // defaults to tcp protocol
+
+	if protoParts := strings.Split(bindings, "/"); len(protoParts) == 2 {
+		addrPart = protoParts[0]
+		protocol = strings.ToLower(protoParts[1])
+	}
+
+	splitCount := strings.Count(addrPart, ":")
+	formattedBinding := addrPart
+	switch splitCount {
+	case 1:
+		if addrPart[0] == ':' {
+			formattedBinding = "0" + formattedBinding
+		} 
+		formattedBinding = "0.0.0.0:" + formattedBinding
+	default:
+		return "", "", errors.New("Invalid network binding format")
+	}
+	splitParts := strings.Split(formattedBinding, ":")
+	for _, part := range splitParts {
+		if len(part) < 1 {
+			return "", "", errors.New("Invalid network binding format")
+		}
+	}
+
+	return formattedBinding, protocol, nil
+}

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -1,46 +1,154 @@
 package network
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSanitizeNetworkBindings(t *testing.T) {
+func TestSanitizeNetworkBindingsV2(t *testing.T) {
 	tests := []struct {
+		name     string
 		input    string
-		binding  string
-		protocol string
+		expected PortBinding
 		err      bool
 	}{
+		// valid inputs
 		{
-			input:    ":80",
-			binding:  "0.0.0.0:0:80",
-			protocol: "tcp",
-			err:      false,
+			name:  "Empty host port",
+			input: ":80",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
 		},
 		{
-			input:    "8080:80",
-			binding:  "0.0.0.0:8080:80",
-			protocol: "tcp",
-			err:      false,
+			name:  "Host port and guest port",
+			input: "8080:80",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  8080,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
 		},
 		{
-			input:    "0:80",
-			binding:  "0.0.0.0:0:80",
-			protocol: "tcp",
-			err:      false,
+			name:  "Host port 0 and guest port",
+			input: "0:80",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
+		},
+		{
+			name:  "IP, host port 0, and guest port",
+			input: "192.168.0.3:0:80",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("192.168.0.3"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
+		},
+		{
+			name:  "Default IP, host port 0, and guest port",
+			input: "0.0.0.0:0:80",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
+		},
+		{
+			name:  "Guest port only",
+			input: "80", // V2 handles this correctly now!
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
+		},
+		{
+			name:  "With udp protocol",
+			input: "8080:80/udp",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  8080,
+				GuestPort: 80,
+				Protocol:  "udp",
+			},
+			err: false,
+		},
+		{
+			name:  "Empty IP and host port",
+			input: "::80", // V2 successfully parses this as empty defaults
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
+		},
+		{
+			name:  "Empty IP and host port with tcp",
+			input: "::80/tcp",
+			expected: PortBinding{
+				IP:        netip.MustParseAddr("0.0.0.0"),
+				HostPort:  0,
+				GuestPort: 80,
+				Protocol:  "tcp",
+			},
+			err: false,
+		},
+		// invalid inputs
+		{
+			name:     "Invalid guest port",
+			input:    "0.0.0.0:0:99999",
+			expected: PortBinding{},
+			err:      true,
+		},
+		{
+			name:     "Too many colons",
+			input:    "127.0.0.1:0:0:80",
+			expected: PortBinding{},
+			err:      true,
+		},
+		{
+			name:     "Invalid IP",
+			input:    "192.168.0.256:0:80/tcp",
+			expected: PortBinding{},
+			err:      true,
+		},
+		{
+			name:     "Invalid Protocol",
+			input:    "8080:80/invalid",
+			expected: PortBinding{},
+			err:      true,
 		},
 	}
 	for _, test := range tests {
-
-		bindings, protocol, err := SanitizeNetworkBindings(test.input)
-		assert.Equal(t, test.binding, bindings)
-		assert.Equal(t, test.protocol, protocol)
-		if test.err {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			binding, err := SanitizeNetworkBindings(test.input)
+			if test.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, binding)
+			}
+		})
 	}
 }

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -1,0 +1,46 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeNetworkBindings(t *testing.T) {
+	tests := []struct {
+		input    string
+		binding  string
+		protocol string
+		err      bool
+	}{
+		{
+			input:    ":80",
+			binding:  "0.0.0.0:0:80",
+			protocol: "tcp",
+			err:      false,
+		},
+		{
+			input:    "8080:80",
+			binding:  "0.0.0.0:8080:80",
+			protocol: "tcp",
+			err:      false,
+		},
+		{
+			input:    "0:80",
+			binding:  "0.0.0.0:0:80",
+			protocol: "tcp",
+			err:      false,
+		},
+	}
+	for _, test := range tests {
+
+		bindings, protocol, err := SanitizeNetworkBindings(test.input)
+		assert.Equal(t, test.binding, bindings)
+		assert.Equal(t, test.protocol, protocol)
+		if test.err {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/internal/storage/bootstrap.go
+++ b/internal/storage/bootstrap.go
@@ -62,7 +62,7 @@ func Bootstrap(stateDir string) (err error) {
 
 	// 1. Create sparse files
 	createdDataFile, err := createSparseFile(dataFilePath, 20*1024*1024*1024)
-	if err != nil { 
+	if err != nil {
 		return err
 	}
 	if createdDataFile {

--- a/internal/storage/containerd.go
+++ b/internal/storage/containerd.go
@@ -125,7 +125,7 @@ func (m *Manager) WarmImage(ctx context.Context, imageRef string) error {
 	if err != nil {
 		return fmt.Errorf("read rootfs for %s: %w", imageRef, err)
 	}
-	
+
 	chainID := identity.ChainID(rootFS).String()
 	m.mu.Lock()
 	m.parents[imageRef] = chainID
@@ -146,7 +146,7 @@ func (m *Manager) WarmImage(ctx context.Context, imageRef string) error {
 // This is a pure local operation — no registry or network calls.
 func (m *Manager) Snapshot(ctx context.Context, vmID, imageRef string) (string, error) {
 	imageRef = normalizeImageRef(imageRef)
-	
+
 	m.mu.RLock()
 	parentChainID, exists := m.parents[imageRef]
 	m.mu.RUnlock()

--- a/internal/system/info.go
+++ b/internal/system/info.go
@@ -10,7 +10,7 @@ import (
 
 // Info holds host system resource information.
 type Info struct {
-	CPUCores     int
+	CPUCores      int
 	TotalMemoryMB int64
 }
 

--- a/internal/vsock/dialer.go
+++ b/internal/vsock/dialer.go
@@ -42,14 +42,14 @@ func DialFirecracker(ctx context.Context, udsPath string, port uint32) (net.Conn
 	// 1. Send the handshake command to Firecracker
 	// Format: "CONNECT <PORT>\n"
 	handshake := fmt.Sprintf("CONNECT %d\n", port)
-	
+
 	// Consider writing with a deadline
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetWriteDeadline(deadline)
 	} else {
 		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	}
-	
+
 	if _, err := conn.Write([]byte(handshake)); err != nil {
 		return nil, fmt.Errorf("failed to send CONNECT handshake: %w", err)
 	}

--- a/observer/observer_linux.go
+++ b/observer/observer_linux.go
@@ -120,14 +120,14 @@ func readMemInfo() (memInfo, error) {
 
 // cpuStat holds the raw CPU tick counters from /proc/stat's "cpu" line.
 type cpuStat struct {
-	user      int64
-	nice      int64
-	system    int64
-	idle      int64
-	iowait    int64
-	irq       int64
-	softirq   int64
-	steal     int64
+	user    int64
+	nice    int64
+	system  int64
+	idle    int64
+	iowait  int64
+	irq     int64
+	softirq int64
+	steal   int64
 }
 
 func (s cpuStat) total() int64 {


### PR DESCRIPTION
This pull request refactors and improves the handling of network port binding strings in the deployment process. The main change is the introduction of a new parsing utility for port bindings, which simplifies and standardizes how network binding strings are interpreted and validated. This update also includes a comprehensive test suite for the new parsing logic and cleans up related code in the deployment command.

**Network port binding parsing improvements:**

* Added a new `SanitizeNetworkBindings` function in `internal/network/utils.go` to robustly parse and validate network binding strings, supporting different formats and protocols, and returning a structured `PortBinding` object.
* Updated the deployment command in `cmd/herd/deploy.go` to use the new `SanitizeNetworkBindings` function, removing the previous manual and error-prone parsing logic for port mappings.

**Testing enhancements:**

* Introduced `internal/network/utils_test.go` with extensive unit tests for the new port binding parser, covering both valid and invalid input scenarios.

**Code cleanup and minor improvements:**

* Removed unused imports and streamlined import statements in several files, including `cmd/herd/deploy.go`, `cmd/herd/init.go`, and `cmd/test_boot/main.go`. [[1]](diffhunk://#diff-f05debcfd01afb88c2908d90b82cf7c8d3bb8f7b157cd2b91d8c4632574589dfL11-R14) [[2]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L24-L25) [[3]](diffhunk://#diff-aa018f4b076f4b59794e9ac140db7da3ab0100ac183bec26d19676bf3886a8f9R10-L15)
* Minor code tidying in unrelated files, such as removing extra blank lines and improving type assertion formatting. [[1]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L241) [[2]](diffhunk://#diff-210a587fd70956cbfff3752b980beb4118de7d9d3ce7cb34b826b6aeb9a37f18L309-R309) [[3]](diffhunk://#diff-c4543adf547dce34a7bbfcc9330d87efe2517282cf1e54782f2c145d52f1aed8L172-R174) [[4]](diffhunk://#diff-900c01a7bc1008aa76e465df3ca4f1ed7309aba098fde947d908be70092b3593L24) [[5]](diffhunk://#diff-32b32ff86499a9e297c08cde4d0605cb7dd163e03ab997af9332361d02621718L257)

These changes make the network port binding logic more reliable, maintainable, and easier to test, while also simplifying the deployment command codebase.