### PR TITLE
Sn/cleanup start go file

### DIFF
--- a/cmd/herd/start.go
+++ b/cmd/herd/start.go
@@ -97,7 +97,7 @@ func runDaemon() {
 		interfaceName = cfg.Cloud.Interface
 	}
 	if interfaceName != "" {
-		ip, err := getInterfaceIP(interfaceName)
+		ip, err := network.GetInterfaceIP(interfaceName)
 		if err != nil {
 			log.Printf("Warning: failed to get IP for interface %q: %v", interfaceName, err)
 		} else {
@@ -228,33 +228,4 @@ func buildPool(cfg *config.Config) (*herd.Pool[*http.Client], error) {
 	return herd.New(factory,
 		herd.WithMaxWorkers(cfg.Resources.MaxGlobalVMs),
 	)
-}
-
-func getInterfaceIP(name string) (string, error) {
-	iface, err := net.InterfaceByName(name)
-	if err != nil {
-		return "", err
-	}
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return "", err
-	}
-	for _, addr := range addrs {
-		var ip net.IP
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip = v.IP
-		case *net.IPAddr:
-			ip = v.IP
-		}
-		if ip == nil || ip.IsLoopback() {
-			continue
-		}
-		ip = ip.To4()
-		if ip == nil {
-			continue // skip ipv6 for now
-		}
-		return ip.String(), nil
-	}
-	return "", fmt.Errorf("no suitable IPv4 address found for interface %s", name)
 }

--- a/internal/network/ipam.go
+++ b/internal/network/ipam.go
@@ -11,7 +11,9 @@ import (
 type IPAM struct {
 	mu      sync.Mutex
 	subnet  *net.IPNet
-	usedIPs map[string]bool
+	// we need this incase, an IP got returned and we are
+	// iterating the range again, this will allow us to reuse the IP
+	usedIPs map[string]bool 
 	nextIP  net.IP
 }
 
@@ -51,9 +53,9 @@ func (i *IPAM) Acquire() (string, error) {
 			inc(i.nextIP)
 			if !i.subnet.Contains(i.nextIP) || isBroadcast(i.nextIP, i.subnet) {
 				// wrap around to the beginning (.2)
-				copy(i.nextIP, i.subnet.IP)
-				inc(i.nextIP)
-				inc(i.nextIP)
+				copy(i.nextIP, i.subnet.IP) // reset back to start of subnet
+				inc(i.nextIP) // .0 is not allowed
+				inc(i.nextIP) // .1 is reserved for host
 			}
 			return res, nil
 		}
@@ -79,6 +81,7 @@ func (i *IPAM) Release(ip string) {
 	delete(i.usedIPs, ip)
 }
 
+// will work for both v4 and v6, we only work with v4
 func inc(ip net.IP) {
 	for j := len(ip) - 1; j >= 0; j-- {
 		ip[j]++
@@ -88,6 +91,9 @@ func inc(ip net.IP) {
 	}
 }
 
+// assume ip is already in the subnet, 
+// essentially any ip in the subnet, will have the mask as 0, 
+// and if all the host bit with mask 0 are 1, we will get 255 for every byte
 func isBroadcast(ip net.IP, n *net.IPNet) bool {
 	if len(ip) != len(n.Mask) {
 		return false

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"errors"
+	"net"
 	"net/netip"
 	"slices"
 	"strconv"
@@ -56,25 +57,25 @@ func SanitizeNetworkBindings(input string) (PortBinding, error) {
 	for i, part := range colon_parts {
 		switch i {
 		case 0:
-			
+
 			// this is the guest port, try to parse this.
 			guestPort, err := strconv.ParseUint(part, 10, 16)
-			if err != nil || guestPort > 65535{
+			if err != nil || guestPort > 65535 {
 				return output, errors.New("Invalid Guest Port")
 			}
 			output.GuestPort = uint16(guestPort)
-		
+
 		case 1:
 			if part == "" {
 				continue // skip parsing, leaves output.HostPort as the default 0
 			}
 			// this is the host port, try to parse this.
 			hostPort, err := strconv.ParseUint(part, 10, 16)
-			if err != nil || hostPort > 65535{
+			if err != nil || hostPort > 65535 {
 				return output, errors.New("Invalid Host Port")
 			}
 			output.HostPort = uint16(hostPort)
-		
+
 		case 2:
 			if part == "" {
 				continue // skip parsing, leaves output.HostPort as the default 0
@@ -89,4 +90,33 @@ func SanitizeNetworkBindings(input string) (PortBinding, error) {
 	}
 
 	return output, nil
+}
+
+func GetInterfaceIP(name string) (string, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return "", err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		ip = ip.To4()
+		if ip == nil {
+			continue // skip ipv6 for now
+		}
+		return ip.String(), nil
+	}
+	return "", errors.New("no suitable IPv4 address found for interface")
 }


### PR DESCRIPTION
This pull request refactors how the IP address for a network interface is retrieved and improves the internal IPAM (IP Address Management) logic. The main change is moving the `getInterfaceIP` function from `cmd/herd/start.go` to a new, reusable `GetInterfaceIP` function in `internal/network/utils.go`. There are also code comments and minor logic improvements in the IPAM implementation.

### Refactoring and Code Organization

* Moved the `getInterfaceIP` function from `cmd/herd/start.go` to `internal/network/utils.go`, renamed it to `GetInterfaceIP`, and updated all references to use the new location, improving code reuse and separation of concerns. [[1]](diffhunk://#diff-4cf15602fb33e8ebbd1b0c8d5c717d727360ab025c5b527bb64207d3240acd40L100-R100) [[2]](diffhunk://#diff-4cf15602fb33e8ebbd1b0c8d5c717d727360ab025c5b527bb64207d3240acd40L232-L260) [[3]](diffhunk://#diff-047c0181b8ac155e6df1ef1ca6e6d89db2791309e1ae7f3c21695ce3f96f3ffaR94-R122)
* Added the missing `net` import in `internal/network/utils.go` to support the new `GetInterfaceIP` implementation.

### IPAM Logic and Documentation

* Added comments to the `IPAM` struct and related methods in `internal/network/ipam.go` to clarify the purpose of fields and the logic of methods like `inc` and `isBroadcast`, making the code easier to understand and maintain. [[1]](diffhunk://#diff-fc696bf7e877db6a71927c397d0a836dd51a95c7ee78b7186a2acd9ac344861aR14-R15) [[2]](diffhunk://#diff-fc696bf7e877db6a71927c397d0a836dd51a95c7ee78b7186a2acd9ac344861aR84) [[3]](diffhunk://#diff-fc696bf7e877db6a71927c397d0a836dd51a95c7ee78b7186a2acd9ac344861aR94-R96)
* Improved the logic in the `Acquire` method of `IPAM` by clarifying the wrap-around behavior when the end of the subnet is reached.